### PR TITLE
Basic error reprocessing

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,69 @@ package errors
 
 import "errors"
 
+// ValidationCode represents different classes of validation errors that may
+// occur vs. concrete data inputs.
+type ValidationCode uint16
+
+const (
+	// KindConflict indicates a validation failure in which the schema and data
+	// values are of differing, conflicting kinds - the schema value does not
+	// subsume the data value. Example: data: "foo"; schema: int
+	KindConflict ValidationCode = 1 << iota
+
+	// OutOfBounds indicates a validation failure in which the data and schema have
+	// the same (or subsuming) kinds, but the data is out of schema-defined bounds.
+	// Example: data: 4; schema: int & <4
+	OutOfBounds
+
+	// MissingField indicates a validation failure in which the data lacks
+	// a field that is required in the schema.
+	MissingField
+
+	// ExcessField indicates a validation failure in which the schema is treated as
+	// closed, and the data contains a field not specified in the schema.
+	ExcessField
+)
+
+// ValidationError is a subtype of
+type ValidationError struct {
+	msg string
+}
+
+// Unwrap implements standard Go error unwrapping, relied on by errors.Is.
+//
+// All ValidationErrors wrap the general ErrNotAnInstance sentinel error.
+func (ve *ValidationError) Unwrap() error {
+	return ErrNotAnInstance
+}
+
+// Validation error codes/types
+var (
+	// ErrNotAnInstance is the general error that indicates some data failed validation
+	// against a Thema schema. Use it with errors.Is() to differentiate validation errors
+	// from other classes of failure.
+	ErrNotAnInstance = errors.New("data not a valid instance of schema")
+
+	// ErrInvalidExcessField indicates a validation failure in which the schema is
+	// treated as closed, and the data contains a field not specified in the schema.
+	ErrInvalidExcessField = errors.New("data contains field not present in schema")
+
+	// ErrInvalidMissingField indicates a validation failure in which the data lacks
+	// a field that is required in the schema.
+	ErrInvalidMissingField = errors.New("required field is absent in data")
+
+	// ErrInvalidKindConflict indicates a validation failure in which the schema and
+	// data values are of differing, conflicting kinds - the schema value does not
+	// subsume the data value. Example: data: "foo"; schema: int
+	ErrInvalidKindConflict = errors.New("schema and data are conflicting kinds")
+
+	// ErrInvalidOutOfBounds indicates a validation failure in which the data and
+	// schema have the same (or subsuming) kinds, but the data is out of
+	// schema-defined bounds. Example: data: 4; schema: int & <3
+	ErrInvalidOutOfBounds = errors.New("data is out of schema bounds")
+)
+
+// Lower level general errors
 var (
 	// ErrValueNotExist indicates that a necessary CUE value did not exist.
 	ErrValueNotExist = errors.New("cue value does not exist")
@@ -17,7 +80,7 @@ var (
 
 	// ErrVersionNotExist indicates that no schema exists in a lineage with a
 	// given version.
-	ErrVersionNotExist = errors.New("lineage does not contain schema with version")
+	ErrVersionNotExist = errors.New("lineage does not contain schema with version") // ErrNoSchemaWithVersion
 
 	// ErrMalformedSyntacticVersion indicates a string input of a syntactic
 	// version was malformed.

--- a/impl.go
+++ b/impl.go
@@ -311,17 +311,14 @@ var _ Schema = &UnarySchema{}
 // TODO should this instead be interface{} (ugh ugh wish Go had discriminated unions) like FillPath?
 func (sch *UnarySchema) Validate(data cue.Value) (*Instance, error) {
 	// TODO which approach is actually the right one, unify or subsume? ugh
-	// err := sch.raw.Subsume(data, cue.Concrete(true), cue.Final())
+	// err := sch.raw.Subsume(data, cue.Concrete(true), cue.Final(), cue.All())
 	// if err != nil {
-	// 	return nil, err
+	// 	return nil, mungeValidateErr(err, sch)
 	// }
 
-	x := sch.raw.Unify(data)
-	if err := x.Err(); err != nil {
-		return nil, err
-	}
-	if err := x.Validate(cue.Concrete(true), cue.Final()); err != nil {
-		return nil, err
+	x := sch.defraw.Unify(data)
+	if err := x.Validate(cue.Concrete(true), cue.Final(), cue.All()); err != nil {
+		return nil, mungeValidateErr(err, sch)
 	}
 
 	return &Instance{

--- a/impl.go
+++ b/impl.go
@@ -29,6 +29,10 @@ func (e *ErrNoSchemaWithVersion) Error() string {
 	return fmt.Sprintf("lineage %q does not contain a schema with version %v", e.lin.Name(), e.v)
 }
 
+func defPathFor(name string, v SyntacticVersion) cue.Path {
+	return cue.MakePath(cue.Def(fmt.Sprintf("%s%v%v", name, v[0], v[1])))
+}
+
 // BindLineage takes a raw cue.Value, checks that it is a valid lineage (that it
 // upholds the invariants which undergird Thema's translatability guarantees),
 // and returns the cue.Value wrapped in a Lineage, iff validity checks succeed.
@@ -96,10 +100,16 @@ func BindLineage(raw cue.Value, lib Library, opts ...BindOption) (Lineage, error
 			lin.allv = append(lin.allv, v)
 
 			sch := schiter.Value()
+			defpath := cue.MakePath(cue.Def(fmt.Sprintf("%s%v%v", nam, v[0], v[1])))
+			defsch := lib.UnwrapCUE().FillPath(defpath, sch).LookupPath(defpath)
+			if defsch.Err() != nil {
+				panic(defsch.Err())
+			}
 			lin.allsch = append(lin.allsch, &UnarySchema{
-				raw: sch,
-				lin: lin,
-				v:   v,
+				raw:    sch,
+				defraw: defsch,
+				lin:    lin,
+				v:      v,
 			})
 
 			// No predecessor to compare against with the very first schema
@@ -179,6 +189,8 @@ type UnaryLineage struct {
 	allv   []SyntacticVersion
 	allsch []*UnarySchema
 }
+
+var _ Lineage = &UnaryLineage{}
 
 // UnwrapCUE returns the cue.Value of the entire lineage.
 func (lin *UnaryLineage) UnwrapCUE() cue.Value {
@@ -278,10 +290,13 @@ func synvExists(a []SyntacticVersion, x SyntacticVersion) bool {
 // A UnarySchema is a Go facade over a Thema schema that does not compose any
 // schemas from any other lineages.
 type UnarySchema struct {
-	raw cue.Value
-	lin *UnaryLineage
-	v   SyntacticVersion
+	raw    cue.Value
+	defraw cue.Value
+	lin    *UnaryLineage
+	v      SyntacticVersion
 }
+
+var _ Schema = &UnarySchema{}
 
 // Validate checks that the provided data is valid with respect to the
 // schema. If valid, the data is wrapped in an Instance and returned.
@@ -373,6 +388,10 @@ func (sch *UnarySchema) Version() SyntacticVersion {
 // Lineage returns the lineage that contains this schema.
 func (sch *UnarySchema) Lineage() Lineage {
 	return sch.lin
+}
+
+func (sch *UnarySchema) defPathFor() cue.Path {
+	return defPathFor(sch.lin.Name(), sch.v)
 }
 
 func (sch *UnarySchema) _schema() {}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -9,12 +9,13 @@ import (
 	"cuelang.org/go/cue/load"
 )
 
+// ToOverlay converts an fs.FS into a CUE loader overlay.
 func ToOverlay(prefix string, vfs fs.FS, overlay map[string]load.Source) error {
 	// TODO why not just stick the prefix on automatically...?
 	if !filepath.IsAbs(prefix) {
 		return fmt.Errorf("must provide absolute path prefix when generating cue overlay, got %q", prefix)
 	}
-	err := fs.WalkDir(vfs, ".", (func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(vfs, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -36,7 +37,7 @@ func ToOverlay(prefix string, vfs fs.FS, overlay map[string]load.Source) error {
 
 		overlay[filepath.Join(prefix, path)] = load.FromBytes(b)
 		return nil
-	}))
+	})
 
 	if err != nil {
 		return err

--- a/load/load.go
+++ b/load/load.go
@@ -10,6 +10,7 @@ import (
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
+
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/internal/util"
 )
@@ -30,10 +31,10 @@ func (e *ErrFSNotACueModule) Unwrap() error {
 
 var themamodpath string = filepath.Join("cue.mod", "pkg", "github.com", "grafana", "thema")
 
-// InstancesWithThema wraps and narrows load.Instance in order to allow
+// InstancesWithThema wraps CUE's load.Instance() in order to allow
 // loading .cue files that directly `import "github.com/grafana/thema"`, as
 // lineages are expected to. This is accomplished by constructing a
-// load.Config.Overlay with the thema CUE files dynamically injected under
+// load.Config.Overlay with the Thema CUE files dynamically injected under
 // cue.mod/pkg/, where CUE searches for mod-external imports.
 //
 // This loader is opinionated, preferring simple ease-of-use and fewer degrees

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -34,7 +34,7 @@ func TestInstanceLoadHelper(t *testing.T) {
 		t.Fatal(val.Err())
 	}
 
-	lin, err := thema.BindLineage(val.LookupPath(cue.ParsePath("lin")), thema.NewLibrary(ctx), thema.SkipBuggyChecks())
+	lin, err := thema.BindLineage(val.LookupPath(cue.ParsePath("lin")), thema.NewLibrary(ctx))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -9,6 +9,7 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/encoding/json"
 	cuejson "cuelang.org/go/pkg/encoding/json"
+
 	"github.com/grafana/thema"
 )
 

--- a/validate.go
+++ b/validate.go
@@ -1,1 +1,223 @@
 package thema
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/errors"
+	"cuelang.org/go/cue/token"
+	terrors "github.com/grafana/thema/errors"
+)
+
+type onesidederr struct {
+	schpos, datapos []token.Pos
+	code            terrors.ValidationCode
+	coords          coords
+	val             string
+}
+
+func (e *onesidederr) Error() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%s: validation failed, data is not an instance:", e.coords)
+	switch e.code {
+	case terrors.MissingField:
+		fmt.Fprintf(&buf, "\n\tschema specifies that field exists with type %v", e.val)
+		for _, pos := range e.schpos {
+			fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+		}
+
+		fmt.Fprintf(&buf, "\n\tbut field was absent from data")
+		for _, pos := range e.datapos {
+			fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+		}
+	case terrors.ExcessField:
+		fmt.Fprintf(&buf, "\n\tschema is closed and does not specify field")
+		for _, pos := range e.schpos {
+			fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+		}
+
+		fmt.Fprintf(&buf, "\n\tbut field exists in data with value %v", e.val)
+		for _, pos := range e.datapos {
+			fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+		}
+	}
+
+	return buf.String()
+}
+
+func (e *onesidederr) Unwrap() error {
+	return terrors.ErrNotAnInstance
+}
+
+type twosidederr struct {
+	schpos, datapos []token.Pos
+	code            terrors.ValidationCode
+	coords          coords
+	sv, dv          string
+}
+
+func (e *twosidederr) Error() string {
+	var buf bytes.Buffer
+
+	fmt.Fprintf(&buf, "%s: validation failed, data is not an instance:\n\tschema expected `%s`", e.coords, e.sv)
+	for _, pos := range e.schpos {
+		fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+	}
+
+	fmt.Fprintf(&buf, "\n\tbut data contained `%s`", e.dv)
+	for _, pos := range e.datapos {
+		fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
+	}
+	return buf.String()
+}
+
+func (e *twosidederr) Unwrap() error {
+	return terrors.ErrNotAnInstance
+}
+
+// TODO differentiate this once we have generic composition to support trimming out irrelevant disj branches
+type emptydisjunction struct {
+	schpos, datapos []token.Pos
+	coords          coords
+	brancherrs      []error
+}
+
+func (e *emptydisjunction) Unwrap() error {
+	return terrors.ErrNotAnInstance
+}
+
+type validationFailure []error
+
+func (vf validationFailure) Unwrap() error {
+	return terrors.ErrNotAnInstance
+}
+
+func (vf validationFailure) Error() string {
+	var buf bytes.Buffer
+	for _, e := range vf {
+		fmt.Fprint(&buf, e.Error())
+		fmt.Fprintf(&buf, "\n")
+	}
+
+	return buf.String()
+}
+
+func mungeValidateErr(err error, sch Schema) error {
+	_, is := err.(errors.Error)
+	if !is {
+		return err
+	}
+
+	var errs validationFailure
+	for _, ee := range errors.Errors(err) {
+		// fmt.Println("POS", ee.Position())
+		// fmt.Println("IPOS", ee.InputPositions())
+		// fmt.Println("PATH", ee.Path())
+		// fmt.Println(ee.Msg())
+		//
+		// fmt.Println("DETAILS", errors.Details(ee, nil))
+
+		schpos, datapos := splitTokens(ee.InputPositions())
+		x := coords{
+			sch:       sch,
+			fieldpath: trimThemaPath(ee.Path()),
+		}
+
+		msg, vals := ee.Msg()
+		fmt.Println("MSG", msg, vals)
+		switch len(vals) {
+		case 1:
+			val, ok := vals[0].(string)
+			if !ok {
+				break
+			}
+			err := &onesidederr{
+				schpos:  schpos,
+				datapos: datapos,
+				coords:  x,
+				val:     val,
+			}
+
+			if strings.Contains(msg, "incomplete") {
+				err.code = terrors.MissingField
+			} else if strings.Contains(msg, "not allowed") {
+				err.code = terrors.ExcessField
+			} else {
+				break
+			}
+
+			errs = append(errs, err)
+			continue
+		case 4:
+			schval, svok := vals[0].(string)
+			dataval, dvok := vals[1].(string)
+			schkind, skok := vals[2].(cue.Kind)
+			datakind, dkok := vals[3].(cue.Kind)
+			if !svok || !dvok || !skok || !dkok {
+				break
+			}
+
+			err := &twosidederr{
+				schpos:  schpos,
+				datapos: datapos,
+				coords:  x,
+				sv:      schval,
+				dv:      dataval,
+			}
+			if datakind.IsAnyOf(schkind) {
+				err.code = terrors.OutOfBounds
+			} else {
+				err.code = terrors.KindConflict
+			}
+
+			errs = append(errs, err)
+			continue
+		}
+
+		// We missed a case, wrap CUE err in a plea for help
+		errs = append(errs, fmt.Errorf("no Thema handler for CUE error, please file an issue against github.com/grafana/thema\nto improve this error output!\n\n%w", ee))
+	}
+	return errs
+}
+
+func splitTokens(poslist []token.Pos) (schpos, datapos []token.Pos) {
+	if len(poslist) == 0 {
+		return
+	}
+
+	// We're assuming data is always last. ...Probably safe? Given that we
+	// control the order of operands in the Schema.Validate() calls...
+	dataname := poslist[len(poslist)-1].Filename()
+	var split int
+	for i, pos := range poslist {
+		if pos.Filename() == dataname {
+			split = i
+			break
+		}
+	}
+
+	return poslist[:split], poslist[split:]
+}
+
+func trimThemaPath(parts []string) []string {
+	for i, s := range parts {
+		if s == "seqs" {
+			return parts[i+4:]
+		}
+	}
+
+	// Otherwise, it's one of the defpath patterns - eliminate first element
+	return parts[1:]
+}
+
+type coords struct {
+	sch       Schema
+	fieldpath []string
+}
+
+func (c coords) String() string {
+	return fmt.Sprintf("<%s@v%s>.%s", c.sch.Lineage().Name(), c.sch.Version(), strings.Join(c.fieldpath, "."))
+}

--- a/validate.go
+++ b/validate.go
@@ -113,13 +113,6 @@ func mungeValidateErr(err error, sch Schema) error {
 
 	var errs validationFailure
 	for _, ee := range errors.Errors(err) {
-		// fmt.Println("POS", ee.Position())
-		// fmt.Println("IPOS", ee.InputPositions())
-		// fmt.Println("PATH", ee.Path())
-		// fmt.Println(ee.Msg())
-		//
-		// fmt.Println("DETAILS", errors.Details(ee, nil))
-
 		schpos, datapos := splitTokens(ee.InputPositions())
 		x := coords{
 			sch:       sch,
@@ -127,7 +120,6 @@ func mungeValidateErr(err error, sch Schema) error {
 		}
 
 		msg, vals := ee.Msg()
-		fmt.Println("MSG", msg, vals)
 		switch len(vals) {
 		case 1:
 			val, ok := vals[0].(string)

--- a/validate.go
+++ b/validate.go
@@ -1,0 +1,1 @@
+package thema

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,1 @@
+package thema


### PR DESCRIPTION
Adds very basic reprocessing of errors from their raw CUE form to something more Thema-specific. This basically covers scalars, and works well enough down into nested fields. It's basically the 80% of value for 20% of effort.

This is really bare bones - i omitted putting much in the way of tests in because that's a larger TODO for Thema in general.

Part of #44.