### PR TITLE
encoding/jsonschema: Add JSON Schema exporter

### DIFF
--- a/encoding/jsonschema/jschema.go
+++ b/encoding/jsonschema/jschema.go
@@ -1,0 +1,433 @@
+package jsonschema
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/ast/astutil"
+	"cuelang.org/go/cue/token"
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/encoding/openapi"
+)
+
+// GenerateSchema generates a JSON Schema (Draft 4) schema representation of the
+// provided Thema schema.
+func GenerateSchema(sch thema.Schema) (*ast.File, error) {
+	f, err := openapi.GenerateSchema(sch, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return oapiToJSchema(f).(*ast.File), nil
+}
+
+// FIXME This is a really sloppy first pass. parent is unused, and impl makes bad changes and misses needed changes
+type objmod struct {
+	parent     *objmod
+	ensureNull bool
+}
+
+func oapiToJSchema(f ast.Node) ast.Node {
+	ast.Walk(f, func(n ast.Node) bool {
+		if isObjectSchema(n) {
+			newobjmod(nil, n)
+			return false
+		}
+		return true
+	}, nil)
+
+	return f
+}
+func oapiToJSchema2(f ast.Node) ast.Node {
+	err := scan(nil, f)
+	if err != nil {
+		panic(err)
+	}
+	// var fatal error
+	// ast.Walk(f, func(n ast.Node) bool {
+	// 	if fatal != nil {
+	// 		return false
+	// 	}
+	//
+	// 	sch, err := newSchemaNode(nil, n)
+	// 	if err != nil {
+	// 		if !errors.Is(err, errNotASchema) {
+	// 			fatal = err
+	// 			return false
+	// 		}
+	// 		return true
+	// 	}
+	//
+	// 	sch.process()
+	// 	return false
+	// }, nil)
+
+	return f
+}
+
+func newobjmod(parent *objmod, n ast.Node) {
+	o := &objmod{parent: parent}
+	o.process(n)
+}
+
+func (o *objmod) process(n ast.Node) {
+	var self bool
+	ast.Walk(n, func(n ast.Node) bool {
+		if self && isObjectSchema(n) {
+			newobjmod(o, n)
+			return false
+		}
+		self = true
+
+		if isFieldWithLabel(n, "nullable") {
+			if x, is := n.(*ast.Field).Value.(*ast.BasicLit); is {
+				o.ensureNull = x.Kind == token.TRUE
+			}
+		}
+
+		return true
+	}, nil)
+
+	self = false
+	astutil.Apply(n, func(c astutil.Cursor) bool {
+		if self && isObjectSchema(c.Node()) {
+			// Skip, it's the other's responsibility
+			return false
+		}
+		self = true
+		switch x := c.Node().(type) {
+		case *ast.Field:
+			if l, is := x.Label.(*ast.BasicLit); is {
+				var lval string
+				lval = l.Value
+				if ulv, _ := strconv.Unquote(l.Value); ulv != "" {
+					lval = ulv
+				}
+
+				switch lval {
+				// None of these are allowed in JSON Schema
+				case "example", "readOnly", "writeOnly", "discriminator", "nullable", "xml":
+					c.Delete()
+					return false
+				case "type":
+					if o.ensureNull && !typeContains(x, "null") {
+						x.Value = ast.NewList(x.Value, ast.NewString("null"))
+					}
+				}
+			}
+		}
+		// fmt.Printf("%v %T %s\x", c.Index(), c.Node(), c.Node())
+		return true
+	}, nil)
+}
+
+func isObjectSchema(n ast.Node) bool {
+	var typ, prop bool
+	if x, is := n.(*ast.StructLit); is {
+		for _, el := range x.Elts {
+			if isFieldWithLabel(el, "type") {
+				typ = typeIs(el, "object")
+			}
+			if isFieldWithLabel(el, "properties") {
+				prop = true
+			}
+		}
+	}
+
+	return typ && prop
+}
+
+type processor func(c astutil.Cursor) bool
+
+// makes a processor that deletes any field with a label matching the input key cases
+func makeFieldDeleter(keys ...string) processor {
+	return func(c astutil.Cursor) bool {
+		switch x := c.Node().(type) {
+		case *ast.Field:
+			if l, is := x.Label.(*ast.BasicLit); is {
+				var lval string
+				lval = l.Value
+				if ulv, _ := strconv.Unquote(l.Value); ulv != "" {
+					lval = ulv
+				}
+
+				for _, k := range keys {
+					if lval == k {
+						c.Delete()
+						return false
+					}
+				}
+			}
+		}
+		return false
+	}
+}
+
+// Reports if the provided node is an oapi/json schema `"type": <val>` field,
+// and if <val> is the given typeName. Always false if multiple types are
+// allowed in a list.
+func typeIs(n ast.Node, t string) bool {
+	if !isFieldWithLabel(n, "type") {
+		return false
+	}
+
+	switch x := n.(*ast.Field).Value.(type) {
+	case *ast.BasicLit:
+		return strEq(x, t)
+	case *ast.ListLit:
+		return false // todo allow multi in one
+	default:
+		return false
+	}
+
+	return false
+}
+
+// Reports if the provided node is an oapi/json schema `"type": <val>` field,
+// and if the given typeName is present in <val>.
+func typeContains(n ast.Node, t string) bool {
+	if !isFieldWithLabel(n, "type") {
+		return false
+	}
+
+	switch x := n.(*ast.Field).Value.(type) {
+	case *ast.BasicLit:
+		return strEq(x, t)
+	case *ast.ListLit:
+		return false // todo allow multi in one
+	default:
+		return false
+	}
+
+	return false
+}
+
+func isFieldWithLabel(n ast.Node, label string) bool {
+	if x, is := n.(*ast.Field); is {
+		if l, is := x.Label.(*ast.BasicLit); is {
+			return strEq(l, label)
+		}
+	}
+	return false
+}
+
+func strEq(lit *ast.BasicLit, str string) bool {
+	if lit.Kind != token.STRING {
+		return false
+	}
+	ls, _ := strconv.Unquote(lit.Value)
+	return str == ls || str == lit.Value
+}
+
+// a schnode represents a single openapi schema node
+type schnode struct {
+	parent *schnode
+	n      ast.Node
+	t      string
+}
+
+func getFieldWithLabel(n *ast.StructLit, label string) *ast.Field {
+	for _, el := range n.Elts {
+		if x, is := el.(*ast.Field); is {
+			if lit, is := x.Label.(*ast.BasicLit); is && strEq(lit, label) {
+				return x
+			}
+		}
+	}
+
+	return nil
+}
+
+func getSchemaType(n *ast.StructLit) (string, error) {
+	if f := getFieldWithLabel(n, "type"); f != nil {
+		if lit, is := f.Value.(*ast.BasicLit); is {
+			ls, _ := strconv.Unquote(lit.Value)
+			if ls != "" {
+				return ls, nil
+			}
+			return lit.Value, nil
+		}
+	}
+	return "", errNotASchema
+}
+
+func isLogicOp(n ast.Node) bool {
+	for _, op := range []string{"oneOf", "allOf", "anyOf", "not"} {
+		if isFieldWithLabel(n, op) {
+			return true
+		}
+	}
+	return false
+}
+
+var errNotASchema = errors.New("not a schema node")
+
+func newSchemaNode(parent schemaNode, in ast.Node) (schemaNode, error) {
+	n, is := in.(*ast.StructLit)
+	if !is {
+		return nil, errNotASchema
+	}
+	inner := &schNode{
+		parent: parent.(*schNode),
+		n:      n,
+	}
+
+	typ, err := getSchemaType(n)
+	if err != nil {
+		return nil, err
+	}
+	switch typ {
+	case "object":
+		inner.scanf = func(p *schNode, n *ast.StructLit) error {
+			p.ensureNull = checkNull(n)
+
+			// Recurse down the properties
+			if pf := getFieldWithLabel(n, "properties"); pf != nil {
+				err = scan(p, pf)
+				if err != nil {
+					return err
+				}
+			}
+
+			// And additionalProperties
+			if apf := getFieldWithLabel(n, "additionalProperties"); apf != nil {
+				return scan(p, apf)
+			}
+
+			return nil
+		}
+
+	case "array":
+		inner.scanf = func(p *schNode, n *ast.StructLit) error {
+			p.ensureNull = checkNull(n)
+
+			// Recurse down the items
+			if items := getFieldWithLabel(n, "items"); items != nil {
+				return scan(p, items)
+			}
+
+			return nil
+		}
+	case "integer", "number", "boolean", "string":
+		inner.scanf = func(p *schNode, n *ast.StructLit) error {
+			p.ensureNull = checkNull(n)
+			return nil
+		}
+	default:
+		return nil, fmt.Errorf("unrecognized schema node type %s", typ)
+	}
+
+	return inner, nil
+
+	// Try scanning down to see if we have allOf/oneOf/anyOf/not
+	// if isLogicOp(n) {
+	// 	inner.scanf = func(p *schNode, n *ast.StructLit) error {
+	// 		return scan(p, n.Value)
+	// 	}
+	// 	return inner, nil
+	// }
+
+	// return nil, nil
+}
+
+func checkNull(n *ast.StructLit) bool {
+	if f := getFieldWithLabel(n, "nullable"); f != nil {
+		if x, is := f.Value.(*ast.BasicLit); is {
+			return x.Kind == token.TRUE
+		}
+	}
+	return false
+}
+
+type schNode struct {
+	parent     *schNode
+	n          *ast.StructLit
+	typ        string
+	ensureNull bool
+	scanf      scanfunc
+}
+
+// func (s *schNode) process() error {
+func (s *schNode) process() {
+	if err := s.scanf(s, s.n); err != nil {
+		panic(err)
+	}
+
+	astutil.Apply(s.n, func(c astutil.Cursor) bool {
+		switch x := c.Node().(type) {
+		case *ast.StructLit:
+			return true
+		case *ast.Field:
+			if l, is := x.Label.(*ast.BasicLit); is {
+				var lval string
+				lval = l.Value
+				if ulv, _ := strconv.Unquote(l.Value); ulv != "" {
+					lval = ulv
+				}
+
+				switch lval {
+				// None of these are allowed in JSON Schema
+				case "example", "readOnly", "writeOnly", "discriminator", "nullable", "xml":
+					c.Delete()
+				case "type":
+					if s.ensureNull && !typeContains(x, "null") {
+						x.Value = ast.NewList(x.Value, ast.NewString("null"))
+					}
+				}
+			}
+		}
+		return false
+	}, nil)
+
+	// Add the $schema field to root only
+	if s.parent == nil {
+		s.n.Elts = append(s.n.Elts, &ast.Field{
+			Label: ast.NewString("$schema"),
+			Value: ast.NewString("http://json-schema.org/draft-04/schema#"),
+		})
+	}
+}
+
+func (s *schNode) node() ast.Node {
+	return s.n
+}
+
+type scanfunc func(p *schNode, n *ast.StructLit) error
+
+func scan(p *schNode, n ast.Node) error {
+	var fatal error
+	ast.Walk(n, func(n ast.Node) bool {
+		if fatal != nil {
+			return false
+		}
+
+		sch, err := newSchemaNode(p, n)
+		if err != nil {
+			if errors.Is(err, errNotASchema) {
+				return true
+			}
+
+			// Unexpected error, abort walk
+			fatal = err
+			return false
+		}
+
+		if sch != nil {
+			sch.process()
+		}
+		return sch == nil
+	}, nil)
+
+	return fatal
+}
+
+type opNode struct {
+	*schNode
+}
+
+type schemaNode interface {
+	process()
+	node() ast.Node
+}

--- a/encoding/jsonschema/jschema.go
+++ b/encoding/jsonschema/jschema.go
@@ -20,7 +20,11 @@ func GenerateSchema(sch thema.Schema) (*ast.File, error) {
 		return nil, err
 	}
 
-	return oapiToJSchema2(f).(*ast.File), nil
+	of, err := oapiToJSchema(f)
+	if err != nil {
+		return nil, err
+	}
+	return of.(*ast.File), nil
 }
 
 type schNode struct {
@@ -33,12 +37,9 @@ type schNode struct {
 
 type scanfunc func(p *schNode, n *ast.StructLit) error
 
-func oapiToJSchema2(f ast.Node) ast.Node {
+func oapiToJSchema(f ast.Node) (ast.Node, error) {
 	err := scan(nil, f)
-	if err != nil {
-		panic(err)
-	}
-	return f
+	return f, err
 }
 
 // Reports if the provided node is an oapi/json schema `"type": <val>` field,

--- a/encoding/jsonschema/jschema.go
+++ b/encoding/jsonschema/jschema.go
@@ -218,7 +218,6 @@ func checkNull(n *ast.StructLit) bool {
 	return false
 }
 
-// func (s *schNode) process() error {
 func (s *schNode) process() {
 	if err := s.scanf(s, s.n); err != nil {
 		panic(err)
@@ -238,7 +237,7 @@ func (s *schNode) process() {
 
 				switch lval {
 				// None of these are allowed in JSON Schema
-				case "example", "readOnly", "writeOnly", "discriminator", "nullable", "xml":
+				case "deprecated", "discriminator", "example", "externalDocs", "nullable", "readOnly", "writeOnly", "xml":
 					c.Delete()
 				case "type":
 					if s.ensureNull && !typeContains(x, "null") {

--- a/encoding/jsonschema/jschema_test.go
+++ b/encoding/jsonschema/jschema_test.go
@@ -1,0 +1,314 @@
+package jsonschema
+
+import (
+	"fmt"
+	"testing"
+
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/pkg/encoding/json"
+	"github.com/xeipuuv/gojsonschema"
+)
+
+func TestJSONSchemaRewrite(t *testing.T) {
+	sl := gojsonschema.NewSchemaLoader()
+	sl.Validate = true
+	sl.Draft = gojsonschema.Draft4
+	err := sl.AddSchemas(gojsonschema.NewStringLoader(complexWant))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exp, err := json.Unmarshal([]byte(complexIn))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := json.Unmarshal([]byte(complexWant))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantf, err := format.Node(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = wantf
+
+	mod := oapiToJSchema2(exp)
+
+	// modf, err := format.Node(mod)
+	// if err != nil {
+	// 	t.Fatal(err)
+	// }
+
+	// t.Log(cmp.Diff(string(wantf), string(modf)))
+	j, err := json.Marshal(cuecontext.New().BuildFile(&ast.File{
+		Decls: []ast.Decl{mod.(ast.Expr)},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Println(json.Indent([]byte(j), "", "  "))
+	if err = sl.AddSchemas(gojsonschema.NewStringLoader(j)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+var complexIn = `
+{
+	"allOf": [
+    {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cats": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "example": [
+                  1
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dogs": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "example": [
+                  1
+                ]
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bring_cats": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "email": {
+                        "type": "string",
+                        "example": "cats@email.com"
+                      },
+                      "sms": {
+                        "type": "string",
+                        "nullable": true,
+                        "example": "+12345678"
+                      },
+                      "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        },
+                        "example": {
+                          "name": "Wookie"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "required": [
+                      "email"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "object",
+      "properties": {
+        "playground": {
+          "type": "object",
+          "required": [
+            "feeling",
+            "child"
+          ],
+          "properties": {
+            "feeling": {
+              "type": "string",
+              "example": "Good feeling"
+            },
+            "child": {
+              "type": "object",
+              "required": [
+                "name",
+                "age"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "example": "Steven"
+                },
+                "age": {
+                  "type": "integer",
+                  "example": 5
+                }
+              }
+            },
+            "toy": {
+              "type": "object",
+              "properties": {
+                "breaks_easily": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "color": {
+                  "type": "string",
+                  "description": "Color of the toy"
+                },
+                "type": {
+                  "type": "string",
+									"enum": ["bucket", "shovel"],
+                  "description": "Toy type"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+`
+
+var complexWant = `
+{
+  "allOf": [
+    {
+      "anyOf": [
+        {
+          "type": "object",
+          "properties": {
+            "cats": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dogs": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "bring_cats": {
+              "type": "array",
+              "items": {
+                "allOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "email": {
+                        "type": "string"
+                      },
+                      "sms": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "required": [
+                      "email"
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "type": "object",
+      "$schema": "http://json-schema.org/draft-04/schema#",
+      "properties": {
+        "playground": {
+          "type": "object",
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "required": [
+            "feeling",
+            "child"
+          ],
+          "properties": {
+            "feeling": {
+              "type": "string"
+            },
+            "child": {
+              "type": "object",
+              "required": [
+                "name",
+                "age"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "age": {
+                  "type": "integer"
+                }
+              }
+            },
+            "toy": {
+              "type": "object",
+              "properties": {
+                "breaks_easily": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "color": {
+                  "type": "string",
+                  "description": "Color of the toy"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "bucket",
+                    "shovel"
+                  ],
+                  "description": "Toy type"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$schema": "http://json-schema.org/draft-04/schema#"
+}
+`

--- a/encoding/jsonschema/jschema_test.go
+++ b/encoding/jsonschema/jschema_test.go
@@ -6,7 +6,6 @@ import (
 
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/cuecontext"
-	"cuelang.org/go/cue/format"
 	"cuelang.org/go/pkg/encoding/json"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -15,34 +14,14 @@ func TestJSONSchemaRewrite(t *testing.T) {
 	sl := gojsonschema.NewSchemaLoader()
 	sl.Validate = true
 	sl.Draft = gojsonschema.Draft4
-	err := sl.AddSchemas(gojsonschema.NewStringLoader(complexWant))
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	exp, err := json.Unmarshal([]byte(complexIn))
 	if err != nil {
 		t.Fatal(err)
 	}
-	want, err := json.Unmarshal([]byte(complexWant))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	wantf, err := format.Node(want)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = wantf
 
 	mod := oapiToJSchema2(exp)
 
-	// modf, err := format.Node(mod)
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-
-	// t.Log(cmp.Diff(string(wantf), string(modf)))
 	j, err := json.Marshal(cuecontext.New().BuildFile(&ast.File{
 		Decls: []ast.Decl{mod.(ast.Expr)},
 	}))
@@ -184,131 +163,5 @@ var complexIn = `
       }
     }
   ]
-}
-`
-
-var complexWant = `
-{
-  "allOf": [
-    {
-      "anyOf": [
-        {
-          "type": "object",
-          "properties": {
-            "cats": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "dogs": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              }
-            }
-          }
-        },
-        {
-          "type": "object",
-          "properties": {
-            "bring_cats": {
-              "type": "array",
-              "items": {
-                "allOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "email": {
-                        "type": "string"
-                      },
-                      "sms": {
-                        "type": [
-                          "string",
-                          "null"
-                        ]
-                      },
-                      "properties": {
-                        "type": "object",
-                        "additionalProperties": {
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  {
-                    "required": [
-                      "email"
-                    ]
-                  }
-                ]
-              }
-            }
-          }
-        }
-      ]
-    },
-    {
-      "type": "object",
-      "$schema": "http://json-schema.org/draft-04/schema#",
-      "properties": {
-        "playground": {
-          "type": "object",
-          "$schema": "http://json-schema.org/draft-04/schema#",
-          "required": [
-            "feeling",
-            "child"
-          ],
-          "properties": {
-            "feeling": {
-              "type": "string"
-            },
-            "child": {
-              "type": "object",
-              "required": [
-                "name",
-                "age"
-              ],
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "age": {
-                  "type": "integer"
-                }
-              }
-            },
-            "toy": {
-              "type": "object",
-              "properties": {
-                "breaks_easily": {
-                  "type": "boolean",
-                  "default": false
-                },
-                "color": {
-                  "type": "string",
-                  "description": "Color of the toy"
-                },
-                "type": {
-                  "type": "string",
-                  "enum": [
-                    "bucket",
-                    "shovel"
-                  ],
-                  "description": "Toy type"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
-  "$schema": "http://json-schema.org/draft-04/schema#"
 }
 `

--- a/encoding/openapi/oapi.go
+++ b/encoding/openapi/oapi.go
@@ -32,6 +32,9 @@ func appendSchemaToLineage(b []byte, schemaPath string, lin thema.Lineage) ([]by
 
 // GenerateSchema creates an OpenAPI document that represents the provided Thema
 // Schema as an OpenAPI schema component.
+//
+// Returns the result as a CUE AST, which is suitable for direct manipulation and
+// marshaling to either JSON or YAML.
 func GenerateSchema(sch thema.Schema, cfg *openapi.Config) (*ast.File, error) {
 	// Need it to make an instance
 	rt := (*cue.Runtime)(sch.UnwrapCUE().Context())

--- a/exemplars/exemplars_test.go
+++ b/exemplars/exemplars_test.go
@@ -12,14 +12,6 @@ var allctx = cuecontext.New()
 var dirinst cue.Value
 var alllib thema.Library
 
-var nameOpts = map[string][]thema.BindOption{
-	"defaultchange": {thema.SkipBuggyChecks()},
-	"narrowing":     {},
-	"rename":        {},
-	"expand":        {},
-	"single":        {},
-}
-
 func init() {
 	dirinst = buildAll(allctx)
 	alllib = thema.NewLibrary(allctx)

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.16
 require (
 	cuelang.org/go v0.4.1
 	github.com/spf13/cobra v1.3.0
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,12 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
+github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This introduces an exporter that converts a Thema schema into JSON Schema (Wright draft 4).

What this _actually_ does is run the OpenAPI exporter (which produces OpenAPI 3.0) and then does a bunch of AST hocus pocus to turn it into JSON Schema. I based this implementation on an annoyingly large amount of reading, [this JS implementation](https://github.com/openapi-contrib/openapi-schema-to-json-schema), and [these docs](https://swagger.io/docs/specification/data-models/keywords/).

There are some odds and ends to clean up:

* [x] Handle `format` oddities between OpenAPI and JSON Schema
* [x] Finish blacklisting all the oapi-specific keywords

However, with the AST manipulation pattern in place, these are pretty trivial additions.

This could possibly eventually be contributed back to CUE directly upstream. The preferable implementation there, though, is probably to update the `encoding/openapi` exporter to support oapi 3.1, which was specifically designed to be == to JSON Schema.

Fixes #49