### PR TITLE
Add lineage printing and generation support

### DIFF
--- a/cmd/thema/lineage.go
+++ b/cmd/thema/lineage.go
@@ -1,8 +1,24 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 
+	upcue "cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/ast/astutil"
+	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
+	"cuelang.org/go/cue/load"
+	"cuelang.org/go/cue/parser"
+	"cuelang.org/go/encoding/json"
+	"cuelang.org/go/encoding/jsonschema"
+	"cuelang.org/go/encoding/openapi"
+	"cuelang.org/go/encoding/yaml"
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/encoding/cue"
+	"github.com/grafana/thema/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -13,42 +29,388 @@ var genCmd = &cobra.Command{
 `,
 }
 
-func setupGenCmd(cmd *cobra.Command) {
-	cmd.AddCommand(genCmd)
+var linCmd = &cobra.Command{
+	Use:   "lineage <command>",
+	Short: "Perform operations directly on lineages and schema",
+	Long: `Perform operations directly on lineages and schema.
 
-	genCmd.AddCommand(initLineageCmd)
+Create, modify, and validate Thema lineages. Generate representations
+of Thema lineages and schema in other schema languages.
+`,
+}
+
+type initCommand struct {
+	name    string
+	cuepath string
+	pkgname string
+	nopkg   bool
+	srcpath string
+	input   []byte
+
+	err error
+}
+
+func (ic *initCommand) setup(cmd *cobra.Command) {
+	cmd.AddCommand(linCmd)
+
+	linCmd.AddCommand(initLineageCmd)
+	initLineageCmd.PersistentFlags().StringVarP(&ic.name, "name", "n", "", "String for the #Lineage.name field")
+	initLineageCmd.MarkFlagRequired("name")
+	initLineageCmd.PersistentFlags().StringVarP(&ic.cuepath, "cue-path", "p", "", "CUE expression for subpath at which lineage should be generated")
+	initLineageCmd.PersistentFlags().StringVar(&ic.pkgname, "package-name", "", "name of the package. Defaults to value for --name")
+	initLineageCmd.PersistentFlags().BoolVar(&ic.nopkg, "no-package", false, "Generate lineage without a package directive")
+	// initLineageCmd.PersistentPreRun = ic.prep
+
+	initLineageCmd.AddCommand(initLineageEmptyCmd)
+	initLineageEmptyCmd.Run = ic.run
+	initLineageEmptyCmd.PreRunE = ic.processPackageArgs
+
+	initLineageCmd.AddCommand(initLineageOpenAPICmd)
+	initLineageOpenAPICmd.Flags().StringVar(&ic.srcpath, "src-subpath", "", "Schema path within the OpenAPI document. Default: whole document")
+	initLineageOpenAPICmd.Run = ic.run
+	initLineageOpenAPICmd.PreRunE = ic.processInput
+
+	initLineageCmd.AddCommand(initLineageJSONSchemaCmd)
+	initLineageJSONSchemaCmd.Flags().StringVar(&ic.srcpath, "src-subpath", "", "Schema path within the JSON Schema document (e.g. #/...) Default: whole document")
+	initLineageJSONSchemaCmd.Run = ic.run
+	initLineageJSONSchemaCmd.PreRunE = ic.processInput
+}
+
+func (ic *initCommand) run(cmd *cobra.Command, args []string) {
+	switch cmd.CalledAs() {
+	case "empty":
+		ic.runEmpty(cmd, args)
+	case "jsonschema":
+		ic.runJSONSchema(cmd, args)
+	case "openapi":
+		ic.runOpenAPI(cmd, args)
+	default:
+		panic(fmt.Sprint("unrecognized command ", cmd.CalledAs()))
+	}
+	if ic.err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s\n", ic.err)
+		os.Exit(1)
+	}
+}
+
+func (ic *initCommand) processPackageArgs(cmd *cobra.Command, args []string) error {
+	if ic.name == "" {
+		return fmt.Errorf("must provide a name for lineage via --name")
+	}
+	if ic.nopkg {
+		if ic.pkgname != "" {
+			return fmt.Errorf("cannot pass both --no-package and --package-name")
+		}
+	} else if ic.pkgname == "" {
+		ic.pkgname = ic.name
+	}
+
+	if !ast.IsValidIdent(ic.pkgname) {
+		return fmt.Errorf("%q is not a valid package name", ic.pkgname)
+	}
+	return nil
+}
+
+// process both openapi and json schema, abstract over stdin
+func (ic *initCommand) processInput(cmd *cobra.Command, args []string) error {
+	byt, err := pathOrStdin(args)
+	if err != nil {
+		return err
+	}
+
+	ic.input = byt
+	return nil
+}
+
+var initLineageEmptyCmd = &cobra.Command{
+	Use:   "empty -n <str> [-p <cue-path>] [--package-name <str> | --no-package]",
+	Args:  cobra.MaximumNArgs(0),
+	Short: "Initialize with an empty schema",
+	Long: `Initialize the lineage with an empty schema.
+
+The name for the new lineage must be provided as a single argument.
+
+The generated lineage is printed to stdout.
+`,
+}
+
+func empt() upcue.Value {
+	ctx := cuecontext.New()
+	str := `
+{
+	// TODO (delete me - first schema goes here!)
+} 
+`
+	expr, _ := parser.ParseExpr("empty", str, parser.ParseComments)
+	return ctx.BuildExpr(expr)
+}
+
+func (ic *initCommand) runEmpty(cmd *cobra.Command, args []string) {
+	ctx := cuecontext.New()
+	str := `
+{
+	// TODO (delete me - first schema goes here!)
+} 
+`
+	expr, _ := parser.ParseExpr("empty", str, parser.ParseComments)
+	v := ctx.BuildExpr(expr)
+	linf, err := cue.NewLineage(v, ic.name, ic.pkgname)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	// Have to re-insert because comments get lost somehow by NewLineage()
+	err = cue.InsertSchemaNodeAs(linf, expr, thema.SV(0, 0))
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	b, err := util.FmtNode(linf)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), string(b))
+}
+
+var initLineageJSONSchemaCmd = &cobra.Command{
+	Use:   "jsonschema -n <str> [--src-subpath <path>] [-p <cue-path>] [--package-name <str> | --no-package] <path> ",
+	Args:  cobra.MaximumNArgs(1),
+	Short: "Initialize with a JSON Schema",
+	Long: `Initialize the lineage with one schema, derived from a JSON Schema document.
+
+A JSON Schema document to be converted for the initial lineage schema must be given,
+either via a path argument or as an input to stdin.
+
+The generated lineage is printed to stdout.
+`,
+}
+
+func (ic *initCommand) runJSONSchema(cmd *cobra.Command, args []string) {
+	ctx := cuecontext.New()
+	v := ctx.CompileBytes(ic.input)
+	if v.Err() != nil {
+		ic.err = v.Err()
+		return
+	}
+
+	jcfg := &jsonschema.Config{
+		Root: ic.srcpath,
+	}
+
+	f, err := jsonschema.Extract(v, jcfg)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	sch := ctx.BuildFile(f)
+	// Remove attributes field
+	astutil.Apply(f, func(c astutil.Cursor) bool {
+		if _, ok := c.Node().(*ast.Attribute); ok {
+			astutil.CopyComments(c.Node(), c.Parent().Node())
+			c.Delete()
+		}
+
+		// Only descend into the file/top-level, not within fields
+		_, is := c.Node().(*ast.File)
+		return is
+	}, nil)
+
+	linf, err := cue.NewLineage(sch.Eval(), ic.name, ic.pkgname)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	b, err := util.FmtNode(linf)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), string(b))
+}
+
+var initLineageOpenAPICmd = &cobra.Command{
+	Use: "openapi -n <str> [--src-subpath <path>] [-p <cue-path>] [--package-name <str> | --no-package] <path> ",
+	// Args:  cobra.MaximumNArgs(1),
+	Short: "Initialize with an OpenAPI v3 schema",
+	Long: `Initialize the lineage with one schema, derived from an OpenAPI v3 document.
+
+An OpenAPI document to be converted for the initial lineage schema must be given,
+either via a path argument or as an input to stdin.
+
+The generated lineage is printed to stdout.
+`,
+}
+
+// expects something else to have already gotten the input from either a file
+// or stdin (as we do with pathOrStdin) and passed it as input param
+func inputToFile(input []byte, args []string) (*ast.File, error) {
+	arg := "-"
+	if len(args) > 0 {
+		arg = args[0]
+	}
+
+	cfg := &load.Config{}
+	binsts := load.Instances([]string{arg}, cfg)
+	fmt.Println(binsts[0].BuildFiles[0])
+	bf := binsts[0].OrphanedFiles[0]
+	if bf == nil {
+		return nil, fmt.Errorf("could not load input file")
+	}
+
+	var f *ast.File
+	var err error
+	switch bf.Encoding {
+	case build.YAML:
+		f, err = yaml.Extract("input", input)
+	case build.JSON:
+		expr, err := json.Extract("input", input)
+		if err == nil {
+			f = &ast.File{
+				Decls: []ast.Decl{expr},
+			}
+		}
+	default:
+		err = fmt.Errorf("unsupported encoding: %s", bf.Encoding)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+func (ic *initCommand) runOpenAPI(cmd *cobra.Command, args []string) {
+	ctx := cuecontext.New()
+	cfg := &load.Config{
+		Stdin: bytes.NewBuffer(ic.input),
+	}
+	if len(args) == 0 {
+		args = append(args, "-")
+	}
+	binsts := load.Instances([]string{args[0]}, cfg)
+	bf := binsts[0].OrphanedFiles[0]
+	if bf == nil {
+		ic.err = fmt.Errorf("could not load input file")
+		return
+	}
+
+	var f *ast.File
+	var err error
+	switch bf.Encoding {
+	case build.YAML:
+		f, err = yaml.Extract("input", ic.input)
+	case build.JSON:
+		expr, err := json.Extract("input", ic.input)
+		if err == nil {
+			f = &ast.File{
+				Decls: []ast.Decl{expr},
+			}
+		}
+	default:
+		err = fmt.Errorf("unsupported encoding: %s", bf.Encoding)
+	}
+
+	if err != nil {
+		ic.err = err
+		return
+	}
+	// f, err := inputToFile(ic.input, args)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	rt := (*upcue.Runtime)(ctx)
+	inst, err := rt.CompileFile(f)
+	if err != nil {
+		ic.err = err
+		return
+	}
+	fo, err := openapi.Extract(inst, &openapi.Config{})
+	// Remove info field
+	var done bool
+	astutil.Apply(fo, func(c astutil.Cursor) bool {
+		if x, ok := c.Node().(*ast.Field); ok {
+			n, _, _ := ast.LabelName(x.Label)
+			if n == "info" {
+				c.Delete()
+				done = true
+			}
+		}
+
+		if done {
+			return false
+		}
+		// Only descend into the file/top-level, not within fields
+		_, is := c.Node().(*ast.File)
+		return is
+	}, nil)
+
+	sch := ctx.BuildFile(fo)
+	if ic.srcpath != "" {
+		p := upcue.ParsePath(ic.srcpath)
+		if p.Err() != nil {
+			ic.err = fmt.Errorf("value for --src-subpath is not a valid cue path expression: %w", p.Err())
+			return
+		}
+		// Eval will do dereferencing for us as needed, but may have other unintended
+		// side effects.
+		sch = sch.LookupPath(p).Eval()
+		if !sch.Exists() {
+			ic.err = fmt.Errorf("path %q does not exist in converted schema", p.String())
+			return
+		}
+	}
+
+	linf, err := cue.NewLineage(sch, ic.name, ic.pkgname)
+
+	b, err := util.FmtNode(linf)
+	if err != nil {
+		ic.err = err
+		return
+	}
+
+	fmt.Fprint(cmd.OutOrStdout(), string(b))
 }
 
 var initLineageCmd = &cobra.Command{
 	Use:   "init",
-	Short: "Generate an empty lineage, ready to fill in with schema.",
-	Long: `Generate an empty lineage, ready to fill in with schema.
+	Short: "Generate code for a new lineage",
+	Long: `Generate code for a new lineage.
 
-The name for the new lineage must be provided as a single argument. The empty
-lineage is printed to stdout.
+Each subcommand supports initializing the lineage from a different kind of input source.
 `,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) != 1 {
-			return fmt.Errorf("must exactly one argument, the name of the lineage")
-		}
-
-		fmt.Printf(`package %s
-
-import "github.com/grafana/thema"
-
-thema.#Lineage
-name: "%s"
-seqs: [
-    {
-        schemas: [
-            { // 0.0
-				// First schema (v0.0) goes here! (delete me)
-            },
-        ]
-    },
-]
-`, args[0], args[0])
-
-		return nil
-	},
+	// 	RunE: func(cmd *cobra.Command, args []string) error {
+	// 		if len(args) != 1 {
+	// 			return fmt.Errorf("must exactly one argument, the name of the lineage")
+	// 		}
+	//
+	// 		fmt.Printf(`package %s
+	//
+	// import "github.com/grafana/thema"
+	//
+	// thema.#Lineage
+	// name: "%s"
+	// seqs: [
+	//     {
+	//         schemas: [
+	// 			// v0.0
+	//             {
+	// 				// TODO First schema goes here! (delete me)
+	//             },
+	//         ]
+	//     },
+	// ]
+	// `, args[0], args[0])
+	//
+	// 		return nil
+	// 	},
 }

--- a/cmd/thema/main.go
+++ b/cmd/thema/main.go
@@ -48,12 +48,9 @@ var quiet bool
 var sch thema.Schema
 
 func main() {
-	rootCmd.PersistentFlags().StringVarP(&linfilepath, "lineage", "l", ".", "path to .cue file or directory containing lineage")
-	rootCmd.MarkFlagRequired("lineage")
-	rootCmd.PersistentFlags().StringVarP(&lincuepath, "path", "p", "", "CUE expression for path to the lineage object within file, if not root")
-
 	setupDataCommand(rootCmd)
-	setupGenCmd(rootCmd)
+	ic := &initCommand{}
+	ic.setup(rootCmd)
 
 	// Stop cobra from being so "helpful"
 	for _, cmd := range allCmds {
@@ -85,7 +82,7 @@ This program offers several kinds of behavior for working with Thema:
 * Validating and inspecting of written lineages.
 * Given a valid lineage, provides basic Thema operations (validate, translate,
   [de]hydrate) on some input data.
-* Run an HTTP server that exposes those basic Thema operations to the network. (TODO)
+* Run an HTTP server that exposes basic Thema operations to the network. (TODO)
 * Provides scaffolding for writing lineages, lenses, and schema. (TODO)
 `,
 }

--- a/cmd/thema/main.go
+++ b/cmd/thema/main.go
@@ -70,7 +70,20 @@ func main() {
 }
 
 // List of all commands, for batching stuff
-var allCmds = []*cobra.Command{rootCmd, genCmd, srvCmd, httpCmd, dataCmd, translateCmd, validateCmd, validateAnyCmd}
+var allCmds = []*cobra.Command{
+	rootCmd,
+	srvCmd,
+	httpCmd,
+	dataCmd,
+	translateCmd,
+	validateCmd,
+	validateAnyCmd,
+	linCmd,
+	initLineageCmd,
+	initLineageEmptyCmd,
+	initLineageOpenAPICmd,
+	initLineageJSONSchemaCmd,
+}
 
 var rootCmd = &cobra.Command{
 	Use:   "thema <command>",

--- a/encoding/cue/doc.go
+++ b/encoding/cue/doc.go
@@ -1,0 +1,3 @@
+// Package cue provides helpers for generating CUE text that from Thema objects.
+
+package cue

--- a/encoding/cue/encode.go
+++ b/encoding/cue/encode.go
@@ -20,8 +20,14 @@ import (
 // string. pkgname is used as the returned file's package declaration. If
 // pkgname is empty, the resulting file will have no package declaration.
 func NewLineage(sch cue.Value, name, pkgname string) (*ast.File, error) {
-	b, err := astutil.FmtNode(astutil.Format(sch))
+	x := astutil.Format(sch)
+	switch x.(type) {
+	case *ast.File, ast.Expr:
+		x = astutil.ToExpr(x)
+	}
+	b, err := astutil.FmtNode(x)
 	if err != nil {
+
 		return nil, fmt.Errorf("failed to convert input schema to string: %ww", err)
 	}
 

--- a/encoding/cue/encode.go
+++ b/encoding/cue/encode.go
@@ -1,0 +1,187 @@
+package cue
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/format"
+	"cuelang.org/go/cue/parser"
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/internal/astutil"
+	"github.com/grafana/thema/internal/compat"
+)
+
+// NewLineage constructs a CUE ast.File with a new lineage declaration in it,
+// using the provided cue.Value as the 0.0 schema.
+//
+// The name parameter is used as the lineage name, and must be a non-empty
+// string. pkgname is used as the returned file's package declaration. If
+// pkgname is empty, the resulting file will have no package declaration.
+func NewLineage(sch cue.Value, name, pkgname string) (*ast.File, error) {
+	syn := sch.Syntax(
+		cue.Definitions(true),
+		cue.Hidden(true),
+		cue.Optional(true),
+		cue.Attributes(true),
+		cue.Docs(true),
+	)
+
+	b, err := format.Node(syn)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert input schema to string: %ww", err)
+	}
+
+	vars := linTplVars{
+		PkgName: pkgname,
+		Name:    name,
+		Sch:     string(b),
+	}
+
+	var buf bytes.Buffer
+	err = emptyLineage.Execute(&buf, vars)
+	if err != nil {
+		return nil, fmt.Errorf("template generation failed: %w", err)
+	}
+
+	f, err := parser.ParseFile(name+".cue", buf.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("%s\nerror while parsing generated output: %w\n", buf.String(), err)
+	}
+	return f, nil
+}
+
+type linTplVars struct {
+	PkgName string
+	Name    string
+	Sch     string
+}
+
+// TODO replace with collection of templates
+var emptyLineage = template.Must(template.New("newlin").Parse(`
+{{- if ne .PkgName "" }}package {{ .PkgName }}
+{{end}}
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "{{ .Name }}"
+seqs: [
+    {
+        schemas: [
+            {{ .Sch }},
+        ]
+    },
+]
+`))
+
+// Append adds the provided cue.Value as a new schema to the provided Lineage.
+//
+// If the provided schema is backwards compatible with the latest schema in the
+// lineage, the new schema will be appended to the latest sequence (minor
+// version bump). Otherwise, a new sequence will be created with the provided
+// schema as its only element (major version bump).
+func Append(lin thema.Lineage, sch cue.Value) (ast.Node, error) {
+	linf := tonode(lin.UnwrapCUE()).(*ast.File)
+	schnode := tonode(sch).(*ast.StructLit)
+
+	lv := thema.LatestVersion(lin)
+	lsch := thema.SchemaP(lin, lv)
+	if err := compat.ThemaCompatible(lsch.UnwrapCUE(), sch); err == nil {
+		// Is compatible, append to same sequence
+		tgtv := thema.SyntacticVersion{lv[0], lv[1] + 1}
+		schnode.AddComment(versionComment(tgtv))
+
+		schl, err := astutil.LatestSchemaList(linf)
+		if err != nil {
+			return nil, fmt.Errorf("could not get lineage's latest seq's schema list: %w", err)
+		}
+
+		schl.Elts = append(schl.Elts, schnode)
+		// TODO add boilerplate lenses, etc.
+	} else {
+		// Not compatible, start a new sequence
+		tgtv := thema.SyntacticVersion{lv[0] + 1, 0}
+		schnode.AddComment(versionComment(tgtv))
+
+		seql := astutil.FindSeqs(linf)
+		if seql == nil {
+			return nil, fmt.Errorf("could not find seqs list in lineage input")
+		}
+
+		seql.Elts = append(seql.Elts, newSequenceNode(schnode))
+		// TODO add boilerplate lenses, etc.
+	}
+
+	return linf, nil
+}
+
+func newSequenceNode(sch *ast.StructLit) *ast.StructLit {
+	if sch == nil {
+		sch = ast.NewStruct() // use empty struct
+	}
+
+	return ast.NewStruct(&ast.Field{
+		Label: ast.NewString("schemas"),
+		Value: ast.NewList(sch),
+	})
+}
+
+func versionComment(v thema.SyntacticVersion) *ast.CommentGroup {
+	return &ast.CommentGroup{
+		Doc:  true,
+		Line: true,
+		List: []*ast.Comment{
+			&ast.Comment{
+				Text: fmt.Sprint("// ", v.String()),
+			},
+		},
+	}
+}
+
+// Into prints a
+func Into(lin thema.Lineage, v cue.Value, p cue.Path) (ast.Node, error) {
+	panic("TODO")
+}
+
+func fmtn(n ast.Node) []byte {
+	b, err := format.Node(n)
+	if err != nil {
+		panic(fmt.Errorf("failed to convert input schema to string: %w", err))
+	}
+	b, err = format.Source(b, format.TabIndent(true), format.Simplify())
+	if err != nil {
+		panic(fmt.Errorf("could not reformat to canonical source form: %w", err))
+	}
+	return b
+}
+
+func tonode(v cue.Value) ast.Node {
+	n := v.Syntax(
+		cue.Raw(),
+		cue.Definitions(true),
+		cue.Hidden(true),
+		cue.Optional(true),
+		cue.Attributes(true),
+		cue.Docs(true),
+	)
+
+	sanitizeBottomLiteral(n)
+	return n
+}
+
+// Removes the comment that the CUE internal exporter adds on bottom literals,
+// which can cause format.Node to produce invalid CUE. This seems to only happen
+// because the CUE compiler injects these comments on a bottom when it's a
+// literal in the source
+//
+// TODO file a bug upstream, we shouldn't have to do this
+func sanitizeBottomLiteral(n ast.Node) {
+	ast.Walk(n, func(n ast.Node) bool {
+		if x, ok := n.(*ast.BottomLit); ok {
+			x.SetComments(nil)
+		}
+		return true
+	}, nil)
+}

--- a/encoding/cue/encode_test.go
+++ b/encoding/cue/encode_test.go
@@ -1,0 +1,42 @@
+package cue
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/exemplars"
+)
+
+var ctx = cuecontext.New()
+var lib = thema.NewLibrary(ctx)
+
+func TestDoSimpleGenLineage(t *testing.T) {
+	cuestr := `
+foo: string
+bar: int
+`
+	v := ctx.CompileString(cuestr)
+
+	_, err := NewLineage(v, "somelineage", "testpkg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// fmt.Println(string(fmtn(f)))
+}
+
+func TestSimpleAppendLineage(t *testing.T) {
+	lin, _ := exemplars.NarrowingLineage(lib)
+
+	cuestr := `
+properbool: bool
+foo?: int
+`
+	v := ctx.CompileString(cuestr)
+
+	_, err := Append(lin, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// fmt.Println(string(fmtn(f)))
+}

--- a/encoding/cue/encode_test.go
+++ b/encoding/cue/encode_test.go
@@ -18,11 +18,12 @@ bar: int
 `
 	v := ctx.CompileString(cuestr)
 
-	_, err := NewLineage(v, "somelineage", "testpkg")
+	f, err := NewLineage(v, "somelineage", "testpkg")
 	if err != nil {
 		t.Fatal(err)
 	}
-	// fmt.Println(string(fmtn(f)))
+	_ = f
+	// fmt.Println(string(astutil.FmtNode(f)))
 }
 
 func TestSimpleAppendLineage(t *testing.T) {
@@ -34,9 +35,10 @@ foo?: int
 `
 	v := ctx.CompileString(cuestr)
 
-	_, err := Append(lin, v)
+	f, err := Append(lin, v)
 	if err != nil {
 		t.Fatal(err)
 	}
-	// fmt.Println(string(fmtn(f)))
+	_ = f
+	// fmt.Println(string(astutil.FmtNodeP(f)))
 }

--- a/encoding/cue/tmpl/lineage.tmpl
+++ b/encoding/cue/tmpl/lineage.tmpl
@@ -1,0 +1,13 @@
+{{- if ne .PkgName "" }}package {{ .PkgName }}
+{{end}}
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "{{ .Name }}"
+seqs: [
+    {
+        schemas: [
+            {{ .Sch }},
+        ]
+    },
+]

--- a/encoding/jsonschema/jschema.go
+++ b/encoding/jsonschema/jschema.go
@@ -58,8 +58,6 @@ func typeIs(n ast.Node, t string) bool {
 	default:
 		return false
 	}
-
-	return false
 }
 
 // Reports if the provided node is an oapi/json schema `"type": <val>` field,

--- a/encoding/jsonschema/single.cue
+++ b/encoding/jsonschema/single.cue
@@ -1,0 +1,23 @@
+package exemplars
+
+import "github.com/grafana/thema"
+
+single: {
+    description: "Lineage containing one sequence with a single, trivial schema."
+    l: thema.#Lineage & {
+        seqs: [
+            {
+                schemas: [
+                    {
+                        astring: string
+                        anint: int
+                        abool: bool
+                        anopt?: [number, number]
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+oi: #Single: single.l.seqs[0].schemas[0]

--- a/encoding/openapi/3p.yaml
+++ b/encoding/openapi/3p.yaml
@@ -1,0 +1,25 @@
+openapi: openapi 3.0.0
+
+paths:
+  '/test':
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Test'
+
+components:
+  schemas:
+    Test:
+      type: object
+      properties:
+        test:
+          type: integer
+      additionalProperties:
+        type: string
+      'x-patternProperties':
+        "^[A-Z]$":
+          type: string

--- a/encoding/openapi/oapi.yaml
+++ b/encoding/openapi/oapi.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.0
+info:
+  title: expand
+  version: "0.3"
+paths: {}
+components:
+  schemas:
+    expand:
+      type: object
+      required:
+        - init
+      properties:
+        init:
+          type: string
+        optional:
+          type: integer
+        withDefault:
+          type: string
+          enum:
+            - foo
+            - bar
+            - baz
+          default: foo

--- a/internal/astutil/get.go
+++ b/internal/astutil/get.go
@@ -1,0 +1,101 @@
+package astutil
+
+import (
+	"fmt"
+	"strconv"
+
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/token"
+)
+
+// Structish comprises AST types that contain a list of declarations that may be fields.
+type Structish interface {
+	*ast.File | *ast.StructLit
+}
+
+func FindSeqs(n ast.Node) *ast.ListLit {
+	var ret *ast.ListLit
+	ast.Walk(n, func(n ast.Node) bool {
+		if ret != nil {
+			return false
+		}
+		if isFieldWithLabel(n, "seqs") {
+			if x, ok := n.(*ast.Field).Value.(*ast.ListLit); ok {
+				ret = x
+				return false
+			}
+		}
+		return true
+	}, nil)
+	return ret
+}
+
+func LatestSchemaList(n ast.Node) (*ast.ListLit, error) {
+	seqlist := FindSeqs(n)
+	if seqlist == nil {
+		return nil, fmt.Errorf("could not find seqs list in input")
+	}
+	return ListForField(seqlist.Elts[len(seqlist.Elts)-1], "schemas")
+}
+
+func ListForField(n ast.Node, label string) (*ast.ListLit, error) {
+	seqs, err := GetFieldByLabel(n, label)
+	if err != nil {
+		return nil, err
+	}
+	seqlist, is := seqs.Value.(*ast.ListLit)
+	if !is {
+		return nil, fmt.Errorf("expected %q field to be an ast.ListLit, got %T", label, seqs)
+	}
+
+	return seqlist, nil
+}
+
+// GetFieldByLabel returns the ast.Field with a given label from a struct-ish input.
+func GetFieldByLabel(n ast.Node, label string) (*ast.Field, error) {
+	var d []ast.Decl
+	switch x := n.(type) {
+	case *ast.File:
+		d = x.Decls
+	case *ast.StructLit:
+		d = x.Elts
+	default:
+		return nil, fmt.Errorf("not an *ast.File or *ast.StructLit")
+	}
+
+	for _, el := range d {
+		if isFieldWithLabel(el, label) {
+			return el.(*ast.Field), nil
+		}
+	}
+
+	return nil, fmt.Errorf("no field with label %q", label)
+}
+
+func strEq(lit *ast.BasicLit, str string) bool {
+	if lit.Kind != token.STRING {
+		return false
+	}
+	ls, _ := strconv.Unquote(lit.Value)
+	return str == ls || str == lit.Value
+}
+
+func identStrEq(id *ast.Ident, str string) bool {
+	if str == id.Name {
+		return true
+	}
+	ls, _ := strconv.Unquote(id.Name)
+	return str == ls
+}
+
+func isFieldWithLabel(n ast.Node, label string) bool {
+	if x, is := n.(*ast.Field); is {
+		if l, is := x.Label.(*ast.BasicLit); is {
+			return strEq(l, label)
+		}
+		if l, is := x.Label.(*ast.Ident); is {
+			return identStrEq(l, label)
+		}
+	}
+	return false
+}

--- a/internal/compat/compat.go
+++ b/internal/compat/compat.go
@@ -1,0 +1,89 @@
+package compat
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"github.com/grafana/thema"
+)
+
+func CheckSeqs(raw cue.Value) error {
+	seqiter, err := raw.LookupPath(cue.MakePath(cue.Str("seqs"))).List()
+	if err != nil {
+		return fmt.Errorf("not a list: %w", err)
+	}
+
+	var vmaj uint
+	var predecessor cue.Value
+	var predsv thema.SyntacticVersion
+	for seqiter.Next() {
+		var vminor uint
+		schemas := seqiter.Value().LookupPath(cue.MakePath(cue.Str("schemas")))
+		schiter, _ := schemas.List()
+		for schiter.Next() {
+			v := synv(vmaj, vminor)
+			sch := schiter.Value()
+
+			// No predecessor to compare against with the very first schema
+			if !(vminor == 0 && vmaj == 0) {
+				// TODO Marked as buggy until we figure out how to both _not_ require
+				// schema to be closed in the .cue file, _and_ how to detect default changes
+				// if !cfg.skipbuggychecks {
+				// The sequences and schema in the candidate lineage must follow
+				// backwards [in]compatibility rules.
+				// TODO Subsumption may not be what we actually want to check here,
+				// as it does not allow the addition of required fields with defaults
+				bcompat := ThemaCompatible(predecessor, sch)
+				if (vminor == 0 && bcompat == nil) || (vminor != 0 && bcompat != nil) {
+					return &CompatInvariantError{
+						rawlin:    raw,
+						violation: [2]thema.SyntacticVersion{predsv, v},
+						detail:    bcompat,
+					}
+				}
+				// }
+			}
+
+			predecessor = sch
+			predsv = v
+			vminor++
+		}
+		vmaj++
+	}
+	return nil
+}
+
+func ThemaCompatible(p, s cue.Value) error {
+	return s.Subsume(p, cue.Raw(), cue.Schema(), cue.Definitions(true), cue.All(), cue.Final())
+}
+
+// Call with no args to get init v, {0, 0}
+// Call with one to get first version in a seq, {x, 0}
+// Call with two because smooth brackets are prettier than curly
+// Call with three or more because len(synv) < len(panic)
+func synv(v ...uint) thema.SyntacticVersion {
+	switch len(v) {
+	case 0:
+		return thema.SyntacticVersion{0, 0}
+	case 1:
+		return thema.SyntacticVersion{v[0], 0}
+	case 2:
+		return thema.SyntacticVersion{v[0], v[1]}
+	default:
+		panic("cmon")
+	}
+}
+
+type CompatInvariantError struct {
+	rawlin    cue.Value
+	violation [2]thema.SyntacticVersion
+	detail    error
+}
+
+func (e *CompatInvariantError) Error() string {
+	if e.violation[0][0] == e.violation[1][0] {
+		// TODO better
+		return e.detail.Error()
+	}
+	return fmt.Sprintf("schema %s must be backwards incompatible with schema %s", e.violation[1], e.violation[0])
+}


### PR DESCRIPTION
This introduces:

* [x] New package for manipulating lineages at the AST level, `encoding/cue` (don't really like this name, but :shrug:)
* [x] CLI commmand for generating empty lineage
* [x] CLI command for generating lineage from openapi, json schema
* ~CLI Options for generating lineages at subpaths~ (deferred)

skipping tests again 😭 best test for this is just golden files, and i'm not gonna one-off that when thema's needs really merit a framework

Fixes #55