### PR TITLE
Add bump subcommand

### DIFF
--- a/cmd/thema/data.go
+++ b/cmd/thema/data.go
@@ -18,9 +18,7 @@ import (
 
 func setupDataCommand(cmd *cobra.Command) {
 	cmd.AddCommand(dataCmd)
-	dataCmd.PersistentFlags().StringVarP(&linfilepath, "lineage", "l", ".", "path to .cue file or directory containing lineage")
-	dataCmd.MarkFlagRequired("lineage")
-	dataCmd.PersistentFlags().StringVarP(&lincuepath, "path", "p", "", "CUE expression for path to the lineage object within file, if not root")
+	addLinPathVars(dataCmd)
 
 	dataCmd.AddCommand(validateCmd)
 	validateCmd.Flags().StringVarP((*string)(&verstr), "version", "v", "", "schema syntactic version to validate data against")

--- a/cmd/thema/lineage.go
+++ b/cmd/thema/lineage.go
@@ -467,13 +467,13 @@ func (bc *bumpCommand) do(cmd *cobra.Command, args []string) error {
 	lv := thema.LatestVersion(lin)
 	lsch := thema.SchemaP(lin, lv)
 	// TODO UGH EVAL
-	schlit := tastutil.Format(lsch.UnwrapCUE().Eval()).(*ast.StructLit)
+	schlit := tastutil.Format(lsch.UnwrapCUE().Eval())
 
 	var err error
 	var nlin ast.Node
 	if bc.maj {
 		nlin = lin.UnwrapCUE().Source()
-		err = cue.InsertSchemaNodeAs(nlin, schlit, thema.SV(lv[0]+1, 0))
+		err = cue.InsertSchemaNodeAs(nlin, tastutil.ToExpr(schlit), thema.SV(lv[0]+1, 0))
 		if err != nil {
 			return err
 		}
@@ -484,7 +484,7 @@ func (bc *bumpCommand) do(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	b, err := tastutil.FmtNode(nlin)
+	b, err := tastutil.FmtNode(tastutil.ToExpr(nlin))
 	if err != nil {
 		return err
 	}

--- a/cmd/thema/load.go
+++ b/cmd/thema/load.go
@@ -103,6 +103,8 @@ func loadone(lib thema.Library, binst *build.Instance, pkgpath, cuepath string) 
 			return nil, fmt.Errorf("no value at path %q in instance %q", cuepath, pkgpath)
 		}
 	}
+	// FIXME so hacky to write back to a global this way - only OK because buildInsts guarantees only one can escape
+	linbinst = binst
 
 	return thema.BindLineage(v, lib)
 }

--- a/encoding/cue/encode.go
+++ b/encoding/cue/encode.go
@@ -59,6 +59,16 @@ func NewLineage(sch cue.Value, name, pkgname string) (*ast.File, error) {
 // generated. The result is not checked for Thema validity. Behavior is
 // undefined if the provided lineage node is not well-formed.
 func InsertSchemaNodeAs(lin ast.Node, sch ast.Expr, v thema.SyntacticVersion) error {
+	seql := astutil.FindSeqs(lin)
+	if seql == nil {
+		return fmt.Errorf("could not find seqs list in input - invalid lineage ast?")
+	}
+	// Handle inserting new sequence path separately
+	if v[0] == uint(len(seql.Elts)) {
+		seql.Elts = append(seql.Elts, newSequenceNode(sch))
+		return nil
+	}
+
 	seql, err := astutil.SchemaListFor(lin, v[0])
 	if err != nil {
 		return err
@@ -142,7 +152,7 @@ func Append(lin thema.Lineage, sch cue.Value) (ast.Node, error) {
 	return linf, nil
 }
 
-func newSequenceNode(sch *ast.StructLit) *ast.StructLit {
+func newSequenceNode(sch ast.Expr) *ast.StructLit {
 	if sch == nil {
 		sch = ast.NewStruct() // use empty struct
 	}

--- a/internal/astutil/get.go
+++ b/internal/astutil/get.go
@@ -123,7 +123,7 @@ func FmtNode(n ast.Node) ([]byte, error) {
 			return nil, err
 		}
 	}
-	b, err := format.Node(n)
+	b, err := format.Node(n, format.TabIndent(true), format.Simplify())
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert input schema to string: %w", err)
 	}
@@ -148,7 +148,6 @@ func FmtNodeP(n ast.Node) []byte {
 // It also sanitizes out weird insertions the CUE compiler makes, as necessary.
 func Format(v cue.Value) ast.Node {
 	n := v.Syntax(
-		cue.Raw(),
 		cue.All(),
 		cue.Definitions(true),
 		cue.Docs(true),


### PR DESCRIPTION
The format/syntax of all the parts of a lineage - notably unfinished #18 - is not easy to write, even for me. It would be a significant UX benefit for the `thema` CLI to be able to scaffold adding a new schema to a lineage.

I expect this command to be essential for new users of Thema that do not want to and should not have to care about indentation levels, all the right brackets and braces, and such. I also expect it to be essential for major versions (where forward and reverse lenses must be written) and large schemas (where just moving all the fields around can become a significant source of error).

Note, however, that this doesn't do anything with lenses yet, pending the changes in #18 