### PR TITLE
cli: Make loaders work independent of disk state

### DIFF
--- a/cmd/thema/lineage_init.go
+++ b/cmd/thema/lineage_init.go
@@ -277,7 +277,7 @@ func inputToFile(input []byte, args []string) (*ast.File, error) {
 			}
 		}
 	default:
-		err = fmt.Errorf("unsupported encoding: %s", bf.Encoding)
+		err = fmt.Errorf("unsupported format: %s", bf.Encoding)
 	}
 
 	if err != nil {

--- a/cmd/thema/lineage_subgen.go
+++ b/cmd/thema/lineage_subgen.go
@@ -23,8 +23,12 @@ type genCommand struct {
 	private bool
 	// don't generate the embed.FS
 	noembed bool
-	lin     thema.Lineage
-	sch     thema.Schema
+
+	// input file format (yaml, json, etc.)
+	format string
+
+	lin thema.Lineage
+	sch thema.Schema
 	// go type to bind to
 	bindtype string
 	// go package name to target
@@ -47,13 +51,13 @@ func (gc *genCommand) setup(cmd *cobra.Command) {
 
 	// genOapiLineageCmd.Flags().StringVarP((*string)(&verstr), "version", "v", "", "schema syntactic version to generate. Defaults to latest")
 	genOapiLineageCmd.Flags().StringVarP(&gc.lla.verstr, "version", "v", "", "schema syntactic version to generate. Defaults to latest")
-	genOapiLineageCmd.Flags().StringVarP(&encoding, "format", "f", "yaml", "output format. \"json\" or \"yaml\".")
+	genOapiLineageCmd.Flags().StringVarP(&gc.format, "format", "f", "yaml", "output format. \"json\" or \"yaml\".")
 	genOapiLineageCmd.Run = gc.run
 
 	genLineageCmd.AddCommand(genJschLineageCmd)
 	// genJschLineageCmd.Flags().StringVarP((*string)(&verstr), "version", "v", "", "schema syntactic version to generate. Defaults to latest")
 	genJschLineageCmd.Flags().StringVarP(&gc.lla.verstr, "version", "v", "", "schema syntactic version to generate. Defaults to latest")
-	genJschLineageCmd.Flags().StringVarP(&encoding, "format", "f", "json", "output format. \"json\" or \"yaml\".")
+	genJschLineageCmd.Flags().StringVarP(&gc.format, "format", "f", "json", "output format. \"json\" or \"yaml\".")
 	genJschLineageCmd.Run = gc.run
 
 	genLineageCmd.AddCommand(genGoTypesLineageCmd)
@@ -126,7 +130,7 @@ Each subcommand supports generating code for a different language target.
 
 Note that the controls offered by each subcommand are intentionally simplified.
 But, each subcommand is implemented as a thin layer atop the packages in
-github.com/grafana/thema/encoding/*. If the CLI lacks the fine-grained control
+github.com/grafana/thema/format/*. If the CLI lacks the fine-grained control
 you require, it is recommended to write your own code generator using those packages.
 `,
 }
@@ -150,7 +154,7 @@ func (gc *genCommand) runOpenAPI(cmd *cobra.Command, args []string) error {
 	}
 
 	var str string
-	switch encoding {
+	switch gc.format {
 	case "json":
 		var b []byte
 		b, err = rt.Context().BuildFile(f).MarshalJSON()
@@ -162,7 +166,7 @@ func (gc *genCommand) runOpenAPI(cmd *cobra.Command, args []string) error {
 	case "yaml", "yml":
 		str, err = yaml.Marshal(rt.Context().BuildFile(f))
 	default:
-		fmt.Fprintf(cmd.ErrOrStderr(), `unrecognized output format %q - must choose "yaml" or "json"`, encoding)
+		fmt.Fprintf(cmd.ErrOrStderr(), `unrecognized output format %q - must choose "yaml" or "json"`, gc.format)
 	}
 	if err != nil {
 		return err
@@ -187,7 +191,7 @@ func (gc *genCommand) runJSONSchema(cmd *cobra.Command, args []string) error {
 	}
 
 	var str string
-	switch encoding {
+	switch gc.format {
 	case "json":
 		var b []byte
 		b, err = rt.Context().BuildFile(f).MarshalJSON()
@@ -199,7 +203,7 @@ func (gc *genCommand) runJSONSchema(cmd *cobra.Command, args []string) error {
 	case "yaml", "yml":
 		str, err = yaml.Marshal(rt.Context().BuildFile(f))
 	default:
-		fmt.Fprintf(cmd.ErrOrStderr(), `unrecognized output format %q - must choose "yaml" or "json"`, encoding)
+		fmt.Fprintf(cmd.ErrOrStderr(), `unrecognized output format %q - must choose "yaml" or "json"`, gc.format)
 	}
 	if err != nil {
 		return err

--- a/cmd/thema/load.go
+++ b/cmd/thema/load.go
@@ -1,14 +1,252 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/build"
+	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/load"
 	"github.com/grafana/thema"
+	terrors "github.com/grafana/thema/errors"
+	"github.com/grafana/thema/internal/util"
+	"github.com/spf13/cobra"
 )
+
+// TODO OMG WOULD BE SO AMAZING TO MAKE THIS ALL JUST USE github.com/grafana/thema/load
+
+type lineageLoadArgs struct {
+	// fs path to the lineage to load. may be absolute or relative, and point to a
+	// file or dir. Also may be "-" for stdin
+	linfilepath string
+
+	// cue path to the lineage to work on (default root)
+	lincuepath string
+
+	// String argument of a version
+	verstr string
+
+	// only do all the loading once
+	once sync.Once
+
+	// Stores all results of running loaders/validators
+	dl *dynamicLoader
+
+	dlerr error
+}
+
+func (lla *lineageLoadArgs) dynLoad() (*dynamicLoader, error) {
+	dl := &dynamicLoader{
+		lla: lla,
+	}
+	// scenarios
+	// - lineage load path has no cue.mod parent (dynamically create cueFS in load dir)
+	// - lineage load path has a cue.mod in some parent (dynamically make a cueFS that includes it; record rel)
+	// - cwd is in the same cue.mod as target lineage
+	// - cwd is different
+	//
+	// loadpath is absolute vs. relative (CUE load.Instances() seems to choke on absolute paths)
+
+	abslfp, err := filepath.Abs(lla.linfilepath)
+	if err != nil {
+		fmt.Errorf("error getting absolute filepath for %s: %w", lla.linfilepath, err)
+	}
+
+	var binsts []*build.Instance
+	var cfg *load.Config
+
+	// GOAL:
+	// cfg.ModuleRoot is the ABSOLUTE path up to the module root, real or virtual
+	// cfg.Module is the name of the module, real or virtual
+	// cfg.Dir is the RELATIVE path, from module root to what we actually want to load, less filename
+
+	info, _ := os.Stat(abslfp)
+	pcm, err := findCueMod(abslfp)
+	dl.virtualmod = err != nil
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("error while searching for cue.mod at or above %s: %w", lla.linfilepath, err)
+		}
+
+		dyndir := abslfp
+		var args []string
+		if !info.IsDir() {
+			args = append(args, filepath.Base(dyndir))
+			dyndir = filepath.Dir(dyndir)
+		}
+
+		overlay := map[string]load.Source{
+			filepath.Join(dyndir, "cue.mod", "module.cue"): load.FromString(`module: ""`),
+		}
+		if err := util.ToOverlay(filepath.Join(dyndir, themamodpath), thema.CueFS, overlay); err != nil {
+			panic(fmt.Sprintf("unreachable - %s", err))
+		}
+		cfg = &load.Config{
+			ModuleRoot: dyndir,
+			Overlay:    overlay,
+			Dir:        dyndir,
+			Package:    "*",
+		}
+
+		binsts = load.Instances(args, cfg)
+	} else {
+		dl.cm = pcm
+
+		overlay := map[string]load.Source{}
+		// do no muckery if in thema mod dir
+		if pcm.modname != "github.com/grafana/thema" {
+			if err := util.ToOverlay(filepath.Join(pcm.cuemodparentdir, themamodpath), thema.CueFS, overlay); err != nil {
+				panic(fmt.Sprintf("unreachable - %s", err))
+			}
+		}
+
+		dl.reltolindir, err = filepath.Rel(pcm.cuemodparentdir, abslfp)
+		if err != nil {
+			return nil, fmt.Errorf("should be unreachable - cue.mod 'parent' path of %s is not rel to lin filepath of %s", pcm.cuemodparentdir, lla.linfilepath)
+		}
+		var args []string
+		if !info.IsDir() {
+			dl.linfilename = filepath.Base(dl.reltolindir)
+			dl.reltolindir = filepath.Dir(dl.reltolindir)
+			args = append(args, dl.linfilename)
+		}
+
+		cfg = &load.Config{
+			ModuleRoot: pcm.cuemodparentdir,
+			Module:     pcm.modname,
+			Overlay:    overlay,
+			// Package:    "*",
+			// Dir:        abslfp,
+			// Dir: dl.reltolindir,
+			Dir: filepath.Join(pcm.cuemodparentdir, dl.reltolindir),
+		}
+		binsts = load.Instances(args, cfg)
+	}
+
+	dl.lin, err = buildInsts(rt, binsts, func(binst *build.Instance) string {
+		if info.IsDir() {
+			return fmt.Sprintf("%s:%s", lla.linfilepath, binst.PkgName)
+		}
+		return lla.linfilepath
+	}, lla.lincuepath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now attach the schema - other validators can decide if what we loaded here
+	// was OK (i.e. if command required explicit input)
+	if lla.verstr == "" {
+		dl.sch = thema.SchemaP(dl.lin, thema.LatestVersion(dl.lin))
+	} else {
+		synv, err := thema.ParseSyntacticVersion(lla.verstr)
+		if err != nil {
+			return nil, err
+		}
+		dl.sch, err = lin.Schema(synv)
+		if err != nil {
+			return nil, fmt.Errorf("schema version %v does not exist in lineage", synv)
+		}
+	}
+
+	return dl, nil
+}
+
+var old bool
+
+// var old bool = true
+
+func (lla *lineageLoadArgs) dynLoadOnce() error {
+	lla.once.Do(func() {
+		if old {
+			var lin thema.Lineage
+			lin, lla.dlerr = lineageFromPaths(rt, lla.linfilepath, lla.lincuepath)
+			lla.dl = &dynamicLoader{
+				lin: lin,
+			}
+		} else {
+			lla.dl, lla.dlerr = lla.dynLoad()
+		}
+	})
+	return lla.dlerr
+}
+
+func (lla *lineageLoadArgs) validateLineageInput(cmd *cobra.Command, args []string) error {
+	if err := lla.dynLoadOnce(); err != nil {
+		if errors.Is(err, terrors.ErrValueNotALineage) && strings.Contains(err.Error(), "instance root") {
+			return fmt.Errorf("%w\nDid you forget to pass a CUE path with -p?", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func (lla *lineageLoadArgs) validateVersionInput(cmd *cobra.Command, args []string) error {
+	if err := lla.dynLoadOnce(); err != nil {
+		return err
+	}
+	if lla.verstr == "" {
+		return fmt.Errorf("must specify an explicit schema version")
+	}
+	return nil
+}
+
+func (lla *lineageLoadArgs) validateVersionInputOptional(cmd *cobra.Command, args []string) error {
+	return lla.dynLoadOnce()
+}
+
+type dynamicLoader struct {
+	lla *lineageLoadArgs
+	cm  *parentCueMod
+	// relative path from the cue mod to the dir containing the loaded lineage, if there was a cue.mod
+	reltolindir string
+	// filename of the lineage, if a single specific filename was provided
+	linfilename string
+
+	// indicates whether the load happened with a virtual cue.mod dir
+	virtualmod bool
+
+	lin thema.Lineage
+
+	sch thema.Schema
+}
+
+// findCueMod recursively searches the given path and its parent directories
+// until one is found containing a cue.mod/module.cue. An error is returned on
+// file read errors, or if no cue.mod was found.
+func findCueMod(path string) (*parentCueMod, error) {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("could not stat path: %w", err)
+	}
+	if !stat.IsDir() {
+		path = filepath.Dir(path)
+	}
+	p := path
+
+	for ; p != filepath.Dir(p); p = filepath.Dir(p) {
+		mpath := filepath.Join(p, "cue.mod", "module.cue")
+		byt, err := os.ReadFile(mpath)
+		if err == nil {
+			modname, err := cuecontext.New().CompileBytes(byt).LookupPath(cue.MakePath(cue.Str("module"))).String()
+			if err != nil {
+				return nil, fmt.Errorf("contents of %s invalid: %w", mpath, err)
+			}
+			return &parentCueMod{
+				cuemodparentdir: p,
+				modname:         modname,
+			}, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("error reading path %s: %w", mpath, err)
+		}
+	}
+	return nil, os.ErrNotExist
+}
 
 // lineageFromPaths takes a filepath and an optional CUE path expression
 // and loads the result up and bind it to a Lineage.
@@ -30,6 +268,15 @@ func lineageFromPaths(rt *thema.Runtime, filepath, cuepath string) (thema.Lineag
 		return filepath
 	}, cuepath)
 }
+
+type parentCueMod struct {
+	// the absolute path to the dir containing cue.mod directory
+	cuemodparentdir string
+	// name of module according to cue.mod/module.cue file
+	modname string
+}
+
+var themamodpath string = filepath.Join("cue.mod", "pkg", "github.com", "grafana", "thema")
 
 func lineageFromStdin(rt *thema.Runtime, b []byte, cuepath string) (thema.Lineage, error) {
 	overlay := map[string]load.Source{

--- a/cmd/thema/main.go
+++ b/cmd/thema/main.go
@@ -1,55 +1,15 @@
 package main
 
 import (
-	"errors"
-	"fmt"
 	"os"
-	"strings"
 
-	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/grafana/thema"
-	terrors "github.com/grafana/thema/errors"
 	"github.com/spf13/cobra"
 )
 
 var ctx = cuecontext.New()
 var rt = thema.NewRuntime(ctx)
-
-// linfilepath is the filesystem path to the file (or directory) containing
-// the lineage
-var linfilepath string
-var lincuepath string
-
-// FIXME this is populated by monumental hack in loadone()
-var linbinst *build.Instance
-
-var lin thema.Lineage
-
-// String argument of a version - "to" with translate and "version" with
-var verstr synvstring
-
-type synvstring string
-
-func (s synvstring) synv() (thema.SyntacticVersion, error) {
-	return thema.ParseSyntacticVersion(string(s))
-}
-
-// encoding of the input data.
-var encoding string
-
-// bytes read from stdin
-var inbytes []byte
-
-// input data, CUEified
-var datval cue.Value
-
-// quiet mode
-var quiet bool
-
-// schema to use
-var sch thema.Schema
 
 func main() {
 	setupDataCommand(rootCmd)
@@ -70,12 +30,6 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
-}
-
-func addLinPathVars(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&linfilepath, "lineage", "l", ".", "path to .cue file or directory containing lineage")
-	cmd.MarkFlagRequired("lineage")
-	cmd.PersistentFlags().StringVarP(&lincuepath, "path", "p", "", "CUE expression for path to the lineage object within file, if not root")
 }
 
 func addLinPathVars2(cmd *cobra.Command, lla *lineageLoadArgs) {
@@ -134,47 +88,4 @@ func mergeCobraefuncs(f ...cobraefunc) cobraefunc {
 
 		return nil
 	}
-}
-
-func validateLineageInput(cmd *cobra.Command, args []string) error {
-	var err error
-	lin, err = lineageFromPaths(rt, linfilepath, lincuepath)
-	if err != nil {
-		if errors.Is(err, terrors.ErrValueNotALineage) && strings.Contains(err.Error(), "instance root") {
-			return fmt.Errorf("%w\nDid you forget to pass a CUE path with -p?", err)
-		}
-		return err
-	}
-	return nil
-}
-
-func validateVersionInput(cmd *cobra.Command, args []string) error {
-	return dovinput(cmd, args, false)
-}
-
-func validateVersionInputOptional(cmd *cobra.Command, args []string) error {
-	return dovinput(cmd, args, true)
-}
-
-func dovinput(cmd *cobra.Command, args []string, opt bool) error {
-	if lin == nil {
-		err := validateLineageInput(cmd, args)
-		if err != nil {
-			return err
-		}
-	}
-	if verstr == "" {
-		if opt {
-			return nil
-		}
-		return errors.New("must pass a schema version with -v")
-	}
-
-	synv, err := verstr.synv()
-	if err != nil {
-		return err
-	}
-
-	sch, err = lin.Schema(synv)
-	return err
 }

--- a/cmd/thema/main.go
+++ b/cmd/thema/main.go
@@ -78,6 +78,12 @@ func addLinPathVars(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&lincuepath, "path", "p", "", "CUE expression for path to the lineage object within file, if not root")
 }
 
+func addLinPathVars2(cmd *cobra.Command, lla *lineageLoadArgs) {
+	cmd.PersistentFlags().StringVarP(&lla.linfilepath, "lineage", "l", ".", "path to .cue file or directory containing lineage")
+	cmd.MarkFlagRequired("lineage")
+	cmd.PersistentFlags().StringVarP(&lla.lincuepath, "path", "p", "", "CUE expression for path to the lineage object within file, if not root")
+}
+
 // List of all commands, for batching stuff
 var allCmds = []*cobra.Command{
 	rootCmd,

--- a/encoding/tgo/gen.go
+++ b/encoding/tgo/gen.go
@@ -174,6 +174,12 @@ type BindingConfig struct {
 	IgnoreDiscoveredImports bool
 }
 
+// generate scenarios:
+// - output is stdout - non-optionally disable generating a cueFS embed var; generate a func instead
+// - there is no cue.mod parent, in which case we dynamically construct one (using what module path?)
+// - there is one, and it's in the output dir - include it directly in cueFS embed
+// - there is one, and it's in the parent of output dir - construct a cueFS from a call to a prefixer
+
 // GenerateLineageBinding generates Go code that makes a Thema lineage defined
 // in a .cue file reliably available in Go via a [thema.LineageFactory] or
 // [thema.ConvergentLineageFactory].

--- a/load/load.go
+++ b/load/load.go
@@ -106,7 +106,7 @@ func InstancesWithThema(modFS fs.FS, dir string, opts ...Option) (*build.Instanc
 	}
 
 	if modname == "" {
-		return nil, &ErrFSNotACueModule{fserr: fmt.Errorf("cue.mod/module.cue did not exist")}
+		return nil, &ErrFSNotACueModule{fserr: fmt.Errorf("cue.mod/module.cue modname was empty")}
 	}
 
 	modroot := filepath.FromSlash(filepath.Join(util.Prefix, modname))


### PR DESCRIPTION
This was just a horrifying situation. This should just about do it - though in a follow-up, i'll need to make Go bindings generators aware of the new improvements and generate smarter `embed.FS` declarations.

Unfortunately, this doesn't do anything really reusable with the `load` package. Turns out, sensitivity to cwd makes the CLI case really different from the "run the binary anywhere" case. Or at least, it's seemed to so far, enough to discourage reuse.

Fixes #79 