### PR TITLE
gocode: Add failed embedding case, fix test

### DIFF
--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -14,7 +14,7 @@ func TestGenerate(t *testing.T) {
 		Name:             "generate",
 		IncludeExemplars: true,
 		ToDo: map[string]string{
-			"TestGenerate/dashboard/0.0/expandrefs": "unexpected problem with converting unification",
+			"embed": "struct embeddings and inlined fields not rendered properly",
 		},
 	}
 
@@ -39,8 +39,9 @@ func TestGenerate(t *testing.T) {
 
 		cuetxtar.ForEachSchema(t, lin, func(t *cuetxtar.LineageTest, sch thema.Schema) {
 			for _, tc := range vars {
-				t.Run(tc.name, func(gt *testing.T) {
-					t.WriteFileOrErrBytes(tc.name + ".go")(GenerateTypesOpenAPI(sch, tc.cfg))
+				itc := tc
+				t.Run(itc.name, func(gt *testing.T) {
+					t.WriteFileOrErrBytes(itc.name + ".go")(GenerateTypesOpenAPI(sch, itc.cfg))
 				})
 			}
 		})

--- a/encoding/gocode/testdata/embed.txtar
+++ b/encoding/gocode/testdata/embed.txtar
@@ -1,0 +1,104 @@
+-- in.cue --
+package generate
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "basic"
+seqs: [
+    {
+        schemas: [
+            {
+                EmbedRef
+                foo: string
+                someField: {
+                    EmbedRef
+                    run: int32
+                    tell: bytes
+                    dat: [...string]
+                }
+            }
+        ]
+    }
+]
+
+EmbedRef: {
+    refField1: string
+    refField2: 42
+}
+
+-- out/generate/0.0/group.go --
+package basic
+
+// Defines values for EmbedRefRefField2.
+const (
+	EmbedRefRefField2N42 EmbedRefRefField2 = 42
+)
+
+// Defines values for RefField2.
+const (
+	RefField2N42 RefField2 = 42
+)
+
+// EmbedRef defines model for EmbedRef.
+type EmbedRef struct {
+	RefField1 string            `json:"refField1"`
+	RefField2 EmbedRefRefField2 `json:"refField2"`
+}
+
+// EmbedRefRefField2 defines model for EmbedRef.RefField2.
+type EmbedRefRefField2 int
+
+// Foo defines model for foo.
+type Foo string
+
+// RefField1 defines model for refField1.
+type RefField1 string
+
+// RefField2 defines model for refField2.
+type RefField2 int
+
+// SomeField defines model for someField.
+type SomeField struct {
+	// Embedded struct due to allOf(#/components/schemas/EmbedRef)
+	EmbedRef `yaml:",inline"`
+	Run  int32 `json:"run"`
+	Tell []byte `json:"tell"`
+	Dat []string `json:"dat"`
+	// Embedded fields due to inline allOf schema
+}
+-- out/generate/0.0/nil.go --
+package basic
+
+// Defines values for EmbedRefRefField2.
+const (
+	EmbedRefRefField2N42 EmbedRefRefField2 = 42
+)
+
+// EmbedRef defines model for EmbedRef.
+type EmbedRef struct {
+	RefField1 string            `json:"refField1"`
+	RefField2 EmbedRefRefField2 `json:"refField2"`
+}
+
+// EmbedRefRefField2 defines model for EmbedRef.RefField2.
+type EmbedRefRefField2 int
+
+// SomeField defines model for someField.
+type SomeField struct {
+	// Embedded struct due to allOf(#/components/schemas/EmbedRef)
+	EmbedRef `yaml:",inline"`
+	Run  int32 `json:"run"`
+	Tell []byte `json:"tell"`
+	Dat []string `json:"dat"`
+	// Embedded fields due to inline allOf schema
+}
+
+// Basic defines model for basic.
+type Basic struct {
+	// Embedded struct due to allOf(#/components/schemas/EmbedRef)
+	EmbedRef `yaml:",inline"`
+	Foo string `json:"foo"`
+	SomeField SomeField `json:"someField"`
+	// Embedded fields due to inline allOf schema
+}

--- a/encoding/gocode/testdata/exemplar_defaultchange.txtar
+++ b/encoding/gocode/testdata/exemplar_defaultchange.txtar
@@ -1,22 +1,3 @@
--- out/generate/0.0/nil.go --
-package defaultchange
-
-// Defines values for DefaultchangeAunion.
-const (
-	DefaultchangeAunionBar DefaultchangeAunion = "bar"
-
-	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
-
-	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
-)
-
-// Defaultchange defines model for defaultchange.
-type Defaultchange struct {
-	Aunion DefaultchangeAunion `json:"aunion"`
-}
-
-// DefaultchangeAunion defines model for Defaultchange.Aunion.
-type DefaultchangeAunion string
 -- out/generate/0.0/group.go --
 package defaultchange
 
@@ -31,7 +12,7 @@ const (
 
 // Aunion defines model for aunion.
 type Aunion string
--- out/generate/1.0/nil.go --
+-- out/generate/0.0/nil.go --
 package defaultchange
 
 // Defines values for DefaultchangeAunion.
@@ -64,3 +45,22 @@ const (
 
 // Aunion defines model for aunion.
 type Aunion string
+-- out/generate/1.0/nil.go --
+package defaultchange
+
+// Defines values for DefaultchangeAunion.
+const (
+	DefaultchangeAunionBar DefaultchangeAunion = "bar"
+
+	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
+
+	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
+)
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Aunion DefaultchangeAunion `json:"aunion"`
+}
+
+// DefaultchangeAunion defines model for Defaultchange.Aunion.
+type DefaultchangeAunion string

--- a/encoding/gocode/testdata/exemplar_disjunct.txtar
+++ b/encoding/gocode/testdata/exemplar_disjunct.txtar
@@ -1,16 +1,9 @@
--- out/generate/0.0/nil.go --
-package disjunct
-
-// Disjunct defines model for disjunct.
-type Disjunct struct {
-	Rootfield interface{} `json:"rootfield"`
-}
 -- out/generate/0.0/group.go --
 package defaultchange
 
 // Rootfield defines model for rootfield.
 type Rootfield interface{}
--- out/generate/0.1/nil.go --
+-- out/generate/0.0/nil.go --
 package disjunct
 
 // Disjunct defines model for disjunct.
@@ -22,3 +15,10 @@ package defaultchange
 
 // Rootfield defines model for rootfield.
 type Rootfield interface{}
+-- out/generate/0.1/nil.go --
+package disjunct
+
+// Disjunct defines model for disjunct.
+type Disjunct struct {
+	Rootfield interface{} `json:"rootfield"`
+}

--- a/encoding/gocode/testdata/exemplar_expand.txtar
+++ b/encoding/gocode/testdata/exemplar_expand.txtar
@@ -1,22 +1,14 @@
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// Init defines model for init.
+type Init string
 -- out/generate/0.0/nil.go --
 package expand
 
 // Expand defines model for expand.
 type Expand struct {
 	Init string `json:"init"`
-}
--- out/generate/0.0/group.go --
-package defaultchange
-
-// Init defines model for init.
-type Init string
--- out/generate/0.1/nil.go --
-package expand
-
-// Expand defines model for expand.
-type Expand struct {
-	Init     string `json:"init"`
-	Optional *int   `json:"optional,omitempty"`
 }
 -- out/generate/0.1/group.go --
 package defaultchange
@@ -26,25 +18,14 @@ type Init string
 
 // Optional defines model for optional.
 type Optional int
--- out/generate/0.2/nil.go --
+-- out/generate/0.1/nil.go --
 package expand
-
-// Defines values for ExpandWithDefault.
-const (
-	ExpandWithDefaultBar ExpandWithDefault = "bar"
-
-	ExpandWithDefaultFoo ExpandWithDefault = "foo"
-)
 
 // Expand defines model for expand.
 type Expand struct {
-	Init        string             `json:"init"`
-	Optional    *int               `json:"optional,omitempty"`
-	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+	Init     string `json:"init"`
+	Optional *int   `json:"optional,omitempty"`
 }
-
-// ExpandWithDefault defines model for Expand.WithDefault.
-type ExpandWithDefault string
 -- out/generate/0.2/group.go --
 package defaultchange
 
@@ -63,14 +44,12 @@ type Optional int
 
 // WithDefault defines model for withDefault.
 type WithDefault string
--- out/generate/0.3/nil.go --
+-- out/generate/0.2/nil.go --
 package expand
 
 // Defines values for ExpandWithDefault.
 const (
 	ExpandWithDefaultBar ExpandWithDefault = "bar"
-
-	ExpandWithDefaultBaz ExpandWithDefault = "baz"
 
 	ExpandWithDefaultFoo ExpandWithDefault = "foo"
 )
@@ -104,3 +83,24 @@ type Optional int
 
 // WithDefault defines model for withDefault.
 type WithDefault string
+-- out/generate/0.3/nil.go --
+package expand
+
+// Defines values for ExpandWithDefault.
+const (
+	ExpandWithDefaultBar ExpandWithDefault = "bar"
+
+	ExpandWithDefaultBaz ExpandWithDefault = "baz"
+
+	ExpandWithDefaultFoo ExpandWithDefault = "foo"
+)
+
+// Expand defines model for expand.
+type Expand struct {
+	Init        string             `json:"init"`
+	Optional    *int               `json:"optional,omitempty"`
+	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+}
+
+// ExpandWithDefault defines model for Expand.WithDefault.
+type ExpandWithDefault string

--- a/encoding/gocode/testdata/exemplar_narrowing.txtar
+++ b/encoding/gocode/testdata/exemplar_narrowing.txtar
@@ -1,3 +1,8 @@
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// Boolish defines model for boolish.
+type Boolish interface{}
 -- out/generate/0.0/nil.go --
 package narrowing
 
@@ -5,11 +10,11 @@ package narrowing
 type Narrowing struct {
 	Boolish interface{} `json:"boolish"`
 }
--- out/generate/0.0/group.go --
+-- out/generate/1.0/group.go --
 package defaultchange
 
-// Boolish defines model for boolish.
-type Boolish interface{}
+// Properbool defines model for properbool.
+type Properbool bool
 -- out/generate/1.0/nil.go --
 package narrowing
 
@@ -17,8 +22,3 @@ package narrowing
 type Narrowing struct {
 	Properbool bool `json:"properbool"`
 }
--- out/generate/1.0/group.go --
-package defaultchange
-
-// Properbool defines model for properbool.
-type Properbool bool

--- a/encoding/gocode/testdata/exemplar_rename.txtar
+++ b/encoding/gocode/testdata/exemplar_rename.txtar
@@ -1,3 +1,11 @@
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// Before defines model for before.
+type Before string
+
+// Unchanged defines model for unchanged.
+type Unchanged string
 -- out/generate/0.0/nil.go --
 package rename
 
@@ -6,11 +14,11 @@ type Rename struct {
 	Before    string `json:"before"`
 	Unchanged string `json:"unchanged"`
 }
--- out/generate/0.0/group.go --
+-- out/generate/1.0/group.go --
 package defaultchange
 
-// Before defines model for before.
-type Before string
+// After defines model for after.
+type After string
 
 // Unchanged defines model for unchanged.
 type Unchanged string
@@ -22,11 +30,3 @@ type Rename struct {
 	After     string `json:"after"`
 	Unchanged string `json:"unchanged"`
 }
--- out/generate/1.0/group.go --
-package defaultchange
-
-// After defines model for after.
-type After string
-
-// Unchanged defines model for unchanged.
-type Unchanged string

--- a/encoding/gocode/testdata/exemplar_single.txtar
+++ b/encoding/gocode/testdata/exemplar_single.txtar
@@ -1,12 +1,3 @@
--- out/generate/0.0/nil.go --
-package single
-
-// Single defines model for single.
-type Single struct {
-	Abool   bool   `json:"abool"`
-	Anint   int    `json:"anint"`
-	Astring string `json:"astring"`
-}
 -- out/generate/0.0/group.go --
 package defaultchange
 
@@ -18,3 +9,12 @@ type Anint int
 
 // Astring defines model for astring.
 type Astring string
+-- out/generate/0.0/nil.go --
+package single
+
+// Single defines model for single.
+type Single struct {
+	Abool   bool   `json:"abool"`
+	Anint   int    `json:"anint"`
+	Astring string `json:"astring"`
+}

--- a/encoding/openapi/testdata/embed.txtar
+++ b/encoding/openapi/testdata/embed.txtar
@@ -1,0 +1,460 @@
+-- in.cue --
+package generate
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "basic"
+seqs: [
+    {
+        schemas: [
+            {
+                EmbedRef
+                foo: string
+                someField: {
+                    EmbedRef
+                    run: int32
+                    tell: bytes
+                    dat: [...string]
+                }
+            }
+        ]
+    }
+]
+
+EmbedRef: {
+    refField1: string
+    refField2: 42
+}
+
+-- out/generate/0.0/expandrefs.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basic",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basic": {
+        "type": "object",
+        "required": [
+          "foo",
+          "refField1",
+          "someField",
+          "refField2"
+        ],
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "refField1": {
+            "type": "string"
+          },
+          "someField": {
+            "type": "object",
+            "required": [
+              "run",
+              "tell",
+              "refField1",
+              "dat",
+              "refField2"
+            ],
+            "properties": {
+              "run": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "tell": {
+                "type": "string",
+                "format": "binary"
+              },
+              "refField1": {
+                "type": "string"
+              },
+              "dat": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "refField2": {
+                "type": "integer",
+                "enum": [
+                  42
+                ]
+              }
+            }
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      }
+    }
+  }
+}
+-- out/generate/0.0/group.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basic",
+    "version": "0.0"
+  },
+  "path": {},
+  "components": {
+    "schemas": {
+      "foo": {
+        "type": "string"
+      },
+      "refField1": {
+        "type": "string"
+      },
+      "EmbedRef": {
+        "type": "object",
+        "required": [
+          "refField1",
+          "refField2"
+        ],
+        "properties": {
+          "refField1": {
+            "type": "string"
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      },
+      "someField": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tell": {
+            "type": "string",
+            "format": "binary"
+          },
+          "dat": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmbedRef"
+          },
+          {
+            "required": [
+              "run",
+              "tell",
+              "dat"
+            ]
+          }
+        ]
+      },
+      "refField2": {
+        "type": "integer",
+        "enum": [
+          42
+        ]
+      }
+    }
+  }
+}
+-- out/generate/0.0/nil.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basic",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "EmbedRef": {
+        "type": "object",
+        "required": [
+          "refField1",
+          "refField2"
+        ],
+        "properties": {
+          "refField1": {
+            "type": "string"
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      },
+      "basic": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "someField": {
+            "type": "object",
+            "properties": {
+              "run": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "tell": {
+                "type": "string",
+                "format": "binary"
+              },
+              "dat": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedRef"
+              },
+              {
+                "required": [
+                  "run",
+                  "tell",
+                  "dat"
+                ]
+              }
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmbedRef"
+          },
+          {
+            "required": [
+              "foo",
+              "someField"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+-- out/generate/0.0/selfcontained.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basic",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "EmbedRef": {
+        "type": "object",
+        "required": [
+          "refField1",
+          "refField2"
+        ],
+        "properties": {
+          "refField1": {
+            "type": "string"
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      },
+      "basic": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          },
+          "someField": {
+            "type": "object",
+            "properties": {
+              "run": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "tell": {
+                "type": "string",
+                "format": "binary"
+              },
+              "dat": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/EmbedRef"
+              },
+              {
+                "required": [
+                  "run",
+                  "tell",
+                  "dat"
+                ]
+              }
+            ]
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmbedRef"
+          },
+          {
+            "required": [
+              "foo",
+              "someField"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+-- out/generate/0.0/subpath.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "someField",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "EmbedRef": {
+        "type": "object",
+        "required": [
+          "refField1",
+          "refField2"
+        ],
+        "properties": {
+          "refField1": {
+            "type": "string"
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      },
+      "someField": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tell": {
+            "type": "string",
+            "format": "binary"
+          },
+          "dat": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmbedRef"
+          },
+          {
+            "required": [
+              "run",
+              "tell",
+              "dat"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+-- out/generate/0.0/subpathroot.json --
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "overriddenName",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "EmbedRef": {
+        "type": "object",
+        "required": [
+          "refField1",
+          "refField2"
+        ],
+        "properties": {
+          "refField1": {
+            "type": "string"
+          },
+          "refField2": {
+            "type": "integer",
+            "enum": [
+              42
+            ]
+          }
+        }
+      },
+      "overriddenName": {
+        "type": "object",
+        "properties": {
+          "run": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tell": {
+            "type": "string",
+            "format": "binary"
+          },
+          "dat": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/EmbedRef"
+          },
+          {
+            "required": [
+              "run",
+              "tell",
+              "dat"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a (failed, todo) test case in encoding/gocode to check the Go code output of embedding a struct within a schema. This is something we want to improve on, and this test case provides us a target of what to fix.

Also fixes what...appear? to be some issues with output ordering in the test, i think due to the shadowed variable in subtest issue.