### PR TITLE
Depointerizer types

### DIFF
--- a/encoding/gocode/decorators.go
+++ b/encoding/gocode/decorators.go
@@ -1,0 +1,112 @@
+package gocode
+
+import (
+	"go/token"
+
+	"github.com/dave/dst"
+	"github.com/dave/dst/dstutil"
+)
+
+func isSingleTypeDecl(gd *dst.GenDecl) bool {
+	if gd.Tok == token.TYPE && len(gd.Specs) == 1 {
+		_, is := gd.Specs[0].(*dst.TypeSpec)
+		return is
+	}
+	return false
+}
+
+func isAdditionalPropertiesStruct(tspec *dst.TypeSpec) (dst.Expr, bool) {
+	strct, is := tspec.Type.(*dst.StructType)
+	if is && len(strct.Fields.List) == 1 && strct.Fields.List[0].Names[0].Name == "AdditionalProperties" {
+		return strct.Fields.List[0].Type, true
+	}
+	return nil, false
+}
+
+func DecoderCompactor() dstutil.ApplyFunc {
+	return func(c *dstutil.Cursor) bool {
+		f, is := c.Node().(*dst.File)
+		if !is {
+			return false
+		}
+
+		compact := make(map[string]bool)
+		// walk the file decls
+		for _, decl := range f.Decls {
+			if fd, is := decl.(*dst.FuncDecl); is {
+				compact[ddepoint(fd.Recv.List[0].Type).(*dst.Ident).Name] = true
+			}
+		}
+		if len(compact) == 0 {
+			return false
+		}
+
+		replace := make(map[string]dst.Expr)
+		// Walk again, looking for types we found
+		for _, decl := range f.Decls {
+			if gd, is := decl.(*dst.GenDecl); is && isSingleTypeDecl(gd) {
+				if tspec := gd.Specs[0].(*dst.TypeSpec); compact[tspec.Name.Name] {
+					if expr, is := isAdditionalPropertiesStruct(tspec); is {
+						replace[tspec.Name.Name] = expr
+					}
+				}
+			}
+		}
+		dstutil.Apply(f, func(c *dstutil.Cursor) bool {
+			switch x := c.Node().(type) {
+			case *dst.FuncDecl:
+				c.Delete()
+			case *dst.GenDecl:
+				if isSingleTypeDecl(x) && compact[x.Specs[0].(*dst.TypeSpec).Name.Name] {
+					c.Delete()
+				}
+			case *dst.Field:
+				if id, is := ddepoint(x.Type).(*dst.Ident); is {
+					if expr, has := replace[id.Name]; has {
+						x.Type = expr
+					}
+				}
+			}
+			return true
+		}, nil)
+		return false
+	}
+}
+
+func ddepoint(e dst.Expr) dst.Expr {
+	if star, is := e.(*dst.StarExpr); is {
+		return star.X
+	}
+	return e
+}
+
+// Depointerizer returns an AST manipulator that removes redundant
+// pointer indirection from all map and slice types.
+func Depointerizer(exprs ...dst.Expr) dstutil.ApplyFunc {
+	depointers := make(map[dst.Expr]bool)
+	for _, expr := range exprs {
+		depointers[expr] = true
+	}
+	return func(c *dstutil.Cursor) bool {
+		switch x := c.Node().(type) {
+		case *dst.Field:
+			if s, is := x.Type.(*dst.StarExpr); is {
+				if len(exprs) == 0 {
+					x.Type = depoint(s)
+					return true
+				}
+				if _, ok := depointers[s]; ok {
+					x.Type = depoint(s)
+				}
+			}
+		}
+		return true
+	}
+}
+
+func depoint(e dst.Expr) dst.Expr {
+	if star, is := e.(*dst.StarExpr); is {
+		return star.X
+	}
+	return e
+}

--- a/encoding/gocode/decorators.go
+++ b/encoding/gocode/decorators.go
@@ -81,7 +81,7 @@ func ddepoint(e dst.Expr) dst.Expr {
 }
 
 // Depointerizer returns an AST manipulator that removes redundant
-// pointer indirection from all map and slice types.
+// pointer indirection from the defined types.
 func Depointerizer(exprs ...dst.Expr) dstutil.ApplyFunc {
 	depointers := make(map[dst.Expr]bool)
 	for _, expr := range exprs {

--- a/encoding/gocode/decorators.go
+++ b/encoding/gocode/decorators.go
@@ -23,7 +23,7 @@ func isAdditionalPropertiesStruct(tspec *dst.TypeSpec) (dst.Expr, bool) {
 	return nil, false
 }
 
-func DecoderCompactor() dstutil.ApplyFunc {
+func decoderCompactor() dstutil.ApplyFunc {
 	return func(c *dstutil.Cursor) bool {
 		f, is := c.Node().(*dst.File)
 		if !is {
@@ -80,9 +80,9 @@ func ddepoint(e dst.Expr) dst.Expr {
 	return e
 }
 
-// Depointerizer returns an AST manipulator that removes redundant
+// depointerizer returns an AST manipulator that removes redundant
 // pointer indirection from the defined types.
-func Depointerizer(exprs ...dst.Expr) dstutil.ApplyFunc {
+func depointerizer(exprs ...dst.Expr) dstutil.ApplyFunc {
 	depointers := make(map[dst.Expr]bool)
 	for _, expr := range exprs {
 		depointers[expr] = true

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -54,7 +54,8 @@ type TypeConfigOpenAPI struct {
 	// default behavior when the fix is usually quite easy.)
 	IgnoreDiscoveredImports bool
 
-	// NoOptionalPointers removes all pointers the types that were marked as optional in cue file.
+	// NoOptionalPointers removes all pointers the types that were marked as optional in cue file
+	// for Go files.
 	NoOptionalPointers bool
 
 	// Config is passed through to the Thema OpenAPI encoder, [openapi.GenerateSchema].

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -54,6 +54,9 @@ type TypeConfigOpenAPI struct {
 	// default behavior when the fix is usually quite easy.)
 	IgnoreDiscoveredImports bool
 
+	// NoOptionalPointers removes all pointers the types that were marked as optional in cue file.
+	NoOptionalPointers bool
+
 	// Config is passed through to the Thema OpenAPI encoder, [openapi.GenerateSchema].
 	Config *openapi.Config
 }
@@ -63,6 +66,12 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 	if cfg == nil {
 		cfg = new(TypeConfigOpenAPI)
 	}
+
+	depointer := Depointerizer(&dst.MapType{}, &dst.ArrayType{})
+	if cfg.NoOptionalPointers {
+		depointer = Depointerizer()
+	}
+	cfg.ApplyFuncs = append(cfg.ApplyFuncs, DecoderCompactor(), depointer)
 
 	f, err := openapi.GenerateSchema(sch, cfg.Config)
 	if err != nil {

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -68,11 +68,11 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 		cfg = new(TypeConfigOpenAPI)
 	}
 
-	depointer := Depointerizer(&dst.MapType{}, &dst.ArrayType{})
+	depointer := depointerizer(&dst.MapType{}, &dst.ArrayType{})
 	if cfg.NoOptionalPointers {
-		depointer = Depointerizer()
+		depointer = depointerizer()
 	}
-	cfg.ApplyFuncs = append(cfg.ApplyFuncs, DecoderCompactor(), depointer)
+	cfg.ApplyFuncs = append(cfg.ApplyFuncs, decoderCompactor(), depointer)
 
 	f, err := openapi.GenerateSchema(sch, cfg.Config)
 	if err != nil {


### PR DESCRIPTION
It moves `DecoderCompactor` from Grafana and create `Depointerizer` function to remove pointers from the types.

By default, we are going to remove always the pointers in maps and slices but in the rest of the types will be optional. So the user could decide to remove these pointers or not setting `NoOptionalPointers` in the configuration.

Related: https://github.com/grafana/grok/issues/1