### PR TITLE
Fix names with spaces

### DIFF
--- a/encoding/typescript/gen.go
+++ b/encoding/typescript/gen.go
@@ -68,6 +68,7 @@ func GenerateTypes(sch thema.Schema, cfg *TypeConfig) (*ast.File, error) {
 	if cfg.RootName == "" {
 		cfg.RootName = strings.Title(sch.Lineage().Name())
 	}
+	cfg.RootName = strings.ReplaceAll(cfg.RootName, " ", "")
 
 	tf, err := cuetsy.GenerateAST(sch.Underlying(), *cfg.CuetsyConfig)
 	if err != nil {
@@ -79,6 +80,7 @@ func GenerateTypes(sch thema.Schema, cfg *TypeConfig) (*ast.File, error) {
 		if cfg.RootAsType {
 			as = cuetsy.TypeAlias
 		}
+
 		top, err := cuetsy.GenerateSingleAST(cfg.RootName, sch.Underlying(), as)
 		if err != nil {
 			return nil, fmt.Errorf("generating TS for schema root failed: %w", err)

--- a/encoding/typescript/gen.go
+++ b/encoding/typescript/gen.go
@@ -80,7 +80,6 @@ func GenerateTypes(sch thema.Schema, cfg *TypeConfig) (*ast.File, error) {
 		if cfg.RootAsType {
 			as = cuetsy.TypeAlias
 		}
-
 		top, err := cuetsy.GenerateSingleAST(cfg.RootName, sch.Underlying(), as)
 		if err != nil {
 			return nil, fmt.Errorf("generating TS for schema root failed: %w", err)


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/pull/62018/files#r1086601395

Sometimes the root name contain spaces and it generates wrong interface names in typescript.