### PR TITLE
Add tests for depointerizer and fixes

### DIFF
--- a/encoding/gocode/decorators.go
+++ b/encoding/gocode/decorators.go
@@ -82,21 +82,18 @@ func ddepoint(e dst.Expr) dst.Expr {
 
 // depointerizer returns an AST manipulator that removes redundant
 // pointer indirection from the defined types.
-func depointerizer(exprs ...dst.Expr) dstutil.ApplyFunc {
-	depointers := make(map[dst.Expr]bool)
-	for _, expr := range exprs {
-		depointers[expr] = true
-	}
+func depointerizer(allTypes bool) dstutil.ApplyFunc {
 	return func(c *dstutil.Cursor) bool {
 		switch x := c.Node().(type) {
 		case *dst.Field:
 			if s, is := x.Type.(*dst.StarExpr); is {
-				if len(exprs) == 0 {
-					x.Type = depoint(s)
+				if allTypes {
+					x.Type = ddepoint(s)
 					return true
 				}
-				if _, ok := depointers[s]; ok {
-					x.Type = depoint(s)
+				switch deref := depoint(s).(type) {
+				case *dst.ArrayType, *dst.MapType:
+					x.Type = deref
 				}
 			}
 		}

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -68,9 +68,9 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 		cfg = new(TypeConfigOpenAPI)
 	}
 
-	depointer := depointerizer(&dst.MapType{}, &dst.ArrayType{})
+	depointer := depointerizer(false)
 	if cfg.NoOptionalPointers {
-		depointer = depointerizer()
+		depointer = depointerizer(true)
 	}
 	cfg.ApplyFuncs = append(cfg.ApplyFuncs, decoderCompactor(), depointer)
 

--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -32,6 +32,12 @@ func TestGenerate(t *testing.T) {
 				Config: &openapi.Config{Group: true},
 			},
 		},
+		{
+			name: "depointerized",
+			cfg: &TypeConfigOpenAPI{
+				NoOptionalPointers: true,
+			},
+		},
 	}
 
 	test.Run(t, func(t *cuetxtar.LineageTest) {

--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -14,7 +14,8 @@ func TestGenerate(t *testing.T) {
 		Name:             "generate",
 		IncludeExemplars: true,
 		ToDo: map[string]string{
-			"embed": "struct embeddings and inlined fields not rendered properly",
+			"embed":       "struct embeddings and inlined fields not rendered properly",
+			"map_pointer": "group doesn't render maps",
 		},
 	}
 

--- a/encoding/gocode/testdata/exemplar_defaultchange.txtar
+++ b/encoding/gocode/testdata/exemplar_defaultchange.txtar
@@ -31,6 +31,25 @@ type Defaultchange struct {
 
 // DefaultchangeAunion defines model for Defaultchange.Aunion.
 type DefaultchangeAunion string
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Defines values for DefaultchangeAunion.
+const (
+	DefaultchangeAunionBar DefaultchangeAunion = "bar"
+
+	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
+
+	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
+)
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Aunion DefaultchangeAunion `json:"aunion"`
+}
+
+// DefaultchangeAunion defines model for Defaultchange.Aunion.
+type DefaultchangeAunion string
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -46,6 +65,25 @@ const (
 // Aunion defines model for aunion.
 type Aunion string
 -- out/generate/1.0/nil.go --
+package defaultchange
+
+// Defines values for DefaultchangeAunion.
+const (
+	DefaultchangeAunionBar DefaultchangeAunion = "bar"
+
+	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
+
+	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
+)
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Aunion DefaultchangeAunion `json:"aunion"`
+}
+
+// DefaultchangeAunion defines model for Defaultchange.Aunion.
+type DefaultchangeAunion string
+-- out/generate/1.0/depointerized.go --
 package defaultchange
 
 // Defines values for DefaultchangeAunion.

--- a/encoding/gocode/testdata/exemplar_disjunct.txtar
+++ b/encoding/gocode/testdata/exemplar_disjunct.txtar
@@ -10,6 +10,13 @@ package disjunct
 type Disjunct struct {
 	Rootfield interface{} `json:"rootfield"`
 }
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Disjunct defines model for disjunct.
+type Disjunct struct {
+	Rootfield interface{} `json:"rootfield"`
+}
 -- out/generate/0.1/group.go --
 package defaultchange
 
@@ -17,6 +24,13 @@ package defaultchange
 type Rootfield interface{}
 -- out/generate/0.1/nil.go --
 package disjunct
+
+// Disjunct defines model for disjunct.
+type Disjunct struct {
+	Rootfield interface{} `json:"rootfield"`
+}
+-- out/generate/0.1/depointerized.go --
+package defaultchange
 
 // Disjunct defines model for disjunct.
 type Disjunct struct {

--- a/encoding/gocode/testdata/exemplar_expand.txtar
+++ b/encoding/gocode/testdata/exemplar_expand.txtar
@@ -10,6 +10,13 @@ package expand
 type Expand struct {
 	Init string `json:"init"`
 }
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Expand defines model for expand.
+type Expand struct {
+	Init string `json:"init"`
+}
 -- out/generate/0.1/group.go --
 package defaultchange
 
@@ -25,6 +32,14 @@ package expand
 type Expand struct {
 	Init     string `json:"init"`
 	Optional *int   `json:"optional,omitempty"`
+}
+-- out/generate/0.1/depointerized.go --
+package defaultchange
+
+// Expand defines model for expand.
+type Expand struct {
+	Init     string `json:"init"`
+	Optional int    `json:"optional,omitempty"`
 }
 -- out/generate/0.2/group.go --
 package defaultchange
@@ -59,6 +74,25 @@ type Expand struct {
 	Init        string             `json:"init"`
 	Optional    *int               `json:"optional,omitempty"`
 	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+}
+
+// ExpandWithDefault defines model for Expand.WithDefault.
+type ExpandWithDefault string
+-- out/generate/0.2/depointerized.go --
+package defaultchange
+
+// Defines values for ExpandWithDefault.
+const (
+	ExpandWithDefaultBar ExpandWithDefault = "bar"
+
+	ExpandWithDefaultFoo ExpandWithDefault = "foo"
+)
+
+// Expand defines model for expand.
+type Expand struct {
+	Init        string            `json:"init"`
+	Optional    int               `json:"optional,omitempty"`
+	WithDefault ExpandWithDefault `json:"withDefault,omitempty"`
 }
 
 // ExpandWithDefault defines model for Expand.WithDefault.
@@ -100,6 +134,27 @@ type Expand struct {
 	Init        string             `json:"init"`
 	Optional    *int               `json:"optional,omitempty"`
 	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+}
+
+// ExpandWithDefault defines model for Expand.WithDefault.
+type ExpandWithDefault string
+-- out/generate/0.3/depointerized.go --
+package defaultchange
+
+// Defines values for ExpandWithDefault.
+const (
+	ExpandWithDefaultBar ExpandWithDefault = "bar"
+
+	ExpandWithDefaultBaz ExpandWithDefault = "baz"
+
+	ExpandWithDefaultFoo ExpandWithDefault = "foo"
+)
+
+// Expand defines model for expand.
+type Expand struct {
+	Init        string            `json:"init"`
+	Optional    int               `json:"optional,omitempty"`
+	WithDefault ExpandWithDefault `json:"withDefault,omitempty"`
 }
 
 // ExpandWithDefault defines model for Expand.WithDefault.

--- a/encoding/gocode/testdata/exemplar_narrowing.txtar
+++ b/encoding/gocode/testdata/exemplar_narrowing.txtar
@@ -10,6 +10,13 @@ package narrowing
 type Narrowing struct {
 	Boolish interface{} `json:"boolish"`
 }
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Narrowing defines model for narrowing.
+type Narrowing struct {
+	Boolish interface{} `json:"boolish"`
+}
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -17,6 +24,13 @@ package defaultchange
 type Properbool bool
 -- out/generate/1.0/nil.go --
 package narrowing
+
+// Narrowing defines model for narrowing.
+type Narrowing struct {
+	Properbool bool `json:"properbool"`
+}
+-- out/generate/1.0/depointerized.go --
+package defaultchange
 
 // Narrowing defines model for narrowing.
 type Narrowing struct {

--- a/encoding/gocode/testdata/exemplar_rename.txtar
+++ b/encoding/gocode/testdata/exemplar_rename.txtar
@@ -14,6 +14,14 @@ type Rename struct {
 	Before    string `json:"before"`
 	Unchanged string `json:"unchanged"`
 }
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Rename defines model for rename.
+type Rename struct {
+	Before    string `json:"before"`
+	Unchanged string `json:"unchanged"`
+}
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -24,6 +32,14 @@ type After string
 type Unchanged string
 -- out/generate/1.0/nil.go --
 package rename
+
+// Rename defines model for rename.
+type Rename struct {
+	After     string `json:"after"`
+	Unchanged string `json:"unchanged"`
+}
+-- out/generate/1.0/depointerized.go --
+package defaultchange
 
 // Rename defines model for rename.
 type Rename struct {

--- a/encoding/gocode/testdata/exemplar_single.txtar
+++ b/encoding/gocode/testdata/exemplar_single.txtar
@@ -18,3 +18,12 @@ type Single struct {
 	Anint   int    `json:"anint"`
 	Astring string `json:"astring"`
 }
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Single defines model for single.
+type Single struct {
+	Abool   bool   `json:"abool"`
+	Anint   int    `json:"anint"`
+	Astring string `json:"astring"`
+}

--- a/encoding/gocode/testdata/map_pointer.txtar
+++ b/encoding/gocode/testdata/map_pointer.txtar
@@ -1,0 +1,36 @@
+-- in.cue --
+package generate
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "pointers"
+seqs: [
+        {
+            schemas: [
+                {
+				    amap?: [string]: string
+				},
+			]
+		},
+	]
+
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// Amap defines model for amap.
+type Amap map[string]string
+-- out/generate/0.0/nil.go --
+package pointers
+
+// Pointers defines model for pointers.
+type Pointers struct {
+	Amap map[string]string `json:"amap,omitempty"`
+}
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Pointers defines model for pointers.
+type Pointers struct {
+	Amap map[string]string `json:"amap,omitempty"`
+}

--- a/encoding/gocode/testdata/pointers.txtar
+++ b/encoding/gocode/testdata/pointers.txtar
@@ -1,0 +1,57 @@
+-- in.cue --
+package generate
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "pointers"
+seqs: [
+        {
+            schemas: [
+                {
+				    astring?: string
+					anint?:   int
+					abool?:   bool
+					alist?: [...string]
+					amap?: [string]: string
+				},
+			]
+		},
+	]
+
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// Abool defines model for abool.
+type Abool bool
+
+// Alist defines model for alist.
+type Alist []string
+
+// Anint defines model for anint.
+type Anint int
+
+// Astring defines model for astring.
+type Astring string
+-- out/generate/0.0/nil.go --
+package pointers
+
+// Pointers defines model for pointers.
+type Pointers struct {
+	Abool   *bool             `json:"abool,omitempty"`
+	Alist   []string          `json:"alist,omitempty"`
+	Amap    map[string]string `json:"amap,omitempty"`
+	Anint   *int              `json:"anint,omitempty"`
+	Astring *string           `json:"astring,omitempty"`
+}
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// Pointers defines model for pointers.
+type Pointers struct {
+	Abool   bool              `json:"abool,omitempty"`
+	Alist   []string          `json:"alist,omitempty"`
+	Amap    map[string]string `json:"amap,omitempty"`
+	Anint   int               `json:"anint,omitempty"`
+	Astring string            `json:"astring,omitempty"`
+}

--- a/encoding/gocode/testdata/pointers.txtar
+++ b/encoding/gocode/testdata/pointers.txtar
@@ -13,7 +13,6 @@ seqs: [
 					anint?:   int
 					abool?:   bool
 					alist?: [...string]
-					amap?: [string]: string
 				},
 			]
 		},
@@ -38,20 +37,18 @@ package pointers
 
 // Pointers defines model for pointers.
 type Pointers struct {
-	Abool   *bool             `json:"abool,omitempty"`
-	Alist   []string          `json:"alist,omitempty"`
-	Amap    map[string]string `json:"amap,omitempty"`
-	Anint   *int              `json:"anint,omitempty"`
-	Astring *string           `json:"astring,omitempty"`
+	Abool   *bool    `json:"abool,omitempty"`
+	Alist   []string `json:"alist,omitempty"`
+	Anint   *int     `json:"anint,omitempty"`
+	Astring *string  `json:"astring,omitempty"`
 }
 -- out/generate/0.0/depointerized.go --
 package defaultchange
 
 // Pointers defines model for pointers.
 type Pointers struct {
-	Abool   bool              `json:"abool,omitempty"`
-	Alist   []string          `json:"alist,omitempty"`
-	Amap    map[string]string `json:"amap,omitempty"`
-	Anint   int               `json:"anint,omitempty"`
-	Astring string            `json:"astring,omitempty"`
+	Abool   bool     `json:"abool,omitempty"`
+	Alist   []string `json:"alist,omitempty"`
+	Anint   int      `json:"anint,omitempty"`
+	Astring string   `json:"astring,omitempty"`
 }


### PR DESCRIPTION
Contributes: https://github.com/grafana/thema/issues/103

It adds txtar tests for `depointerizer` and fixes. I set a map of `map[dst.Expr]bool` and `depointers[s]` was always false 🤡.
Because we have only the use cases to depointerize all or only Map/Array types, I change it with a simple bool.

Idk why map is completely ignore in group [here](https://github.com/grafana/thema/compare/tests-for-depointerizer?expand=1#diff-732bbcd269f0aa495695654a273fa240831261310998f92009d20ec26e4e2741R22-R35).