### PR TITLE
Do a `checkscalar` on NumberKind instead of erroring.

### DIFF
--- a/assignable.go
+++ b/assignable.go
@@ -102,11 +102,9 @@ func assignable(sch cue.Value, T interface{}) error {
 		switch sk {
 		case cue.ListKind:
 			checklist(gval, sval, p)
-		case cue.NumberKind:
-			errs[p.String()] = fmt.Errorf(
-				"%s: CUE number type comprises both floats and ints, may only correspond to interface{}/any", p,
-			)
 		case cue.FloatKind, cue.IntKind, cue.StringKind, cue.BytesKind, cue.BoolKind:
+			checkscalar(gval, sval, p)
+		case cue.NumberKind:
 			checkscalar(gval, sval, p)
 		case cue.StructKind:
 			checkstruct(gval, sval, p)

--- a/schema_test.go
+++ b/schema_test.go
@@ -17,6 +17,7 @@ seqs: [
 			{
 				astring?: string
 				anint:   int64 | *42
+				afloat:  float64
 				abool:   bool
 			}
 		]
@@ -27,6 +28,7 @@ seqs: [
 type TestType struct {
 	Astring *string `json:"astring"`
 	Anint   int64   `json:"anint"`
+	Afloat  float64 `json:"afloat"`
 	Abool   bool    `json:"abool"`
 }
 


### PR DESCRIPTION
`NumberKind` is just `FloatKind | IntKind`. If the scalar field in the Go type is a float, it can hold the value, and we shouldn't error.

Or at least that's my assertion :-) I don't know what peril this may cause, but it solved a BindType panic that seemed invalid.