### PR TITLE
Apply external functions at the end to avoid undesired results

### DIFF
--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -81,8 +81,7 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 		applyFuncs = append(applyFuncs, fixTODOComments())
 	}
 
-	for _, fn := range cfg.ApplyFuncs {
-		applyFuncs = append(applyFuncs, fn)
+	applyFuncs = append(applyFuncs, cfg.ApplyFuncs...)
 	}
 
 	f, err := openapi.GenerateSchema(sch, cfg.Config)

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -80,9 +80,7 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 	if !cfg.UseGoDeclInComments {
 		applyFuncs = append(applyFuncs, fixTODOComments())
 	}
-
 	applyFuncs = append(applyFuncs, cfg.ApplyFuncs...)
-	}
 
 	f, err := openapi.GenerateSchema(sch, cfg.Config)
 	if err != nil {


### PR DESCRIPTION
We were applying the external functions at the beginning modifying the file prior to make the fixes. This approach complicates the fixes of the Go file inside `thema` and they should be at the end.