### PR TITLE
Remove underscores in Go names

### DIFF
--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -75,7 +75,7 @@ func GenerateTypesOpenAPI(sch thema.Schema, cfg *TypeConfigOpenAPI) ([]byte, err
 	if cfg.NoOptionalPointers {
 		depointer = depointerizer(true)
 	}
-	cfg.ApplyFuncs = append(cfg.ApplyFuncs, depointer, fixRawData())
+	cfg.ApplyFuncs = append(cfg.ApplyFuncs, depointer, fixRawData(), fixUnderscoreInTypeName())
 
 	if !cfg.UseGoDeclInComments {
 		cfg.ApplyFuncs = append(cfg.ApplyFuncs, fixTODOComments())

--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -3,6 +3,7 @@ package gocode
 import (
 	"testing"
 
+	copenapi "cuelang.org/go/encoding/openapi"
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/openapi"
 	cuetxtar "github.com/grafana/thema/internal/txtartest"
@@ -43,6 +44,16 @@ func TestGenerate(t *testing.T) {
 			name: "godeclincomments",
 			cfg: &TypeConfigOpenAPI{
 				UseGoDeclInComments: true,
+			},
+		},
+		{
+			name: "expandref",
+			cfg: &TypeConfigOpenAPI{
+				Config: &openapi.Config{
+					Config: &copenapi.Config{
+						ExpandReferences: true,
+					},
+				},
 			},
 		},
 	}

--- a/encoding/gocode/testdata/comments.txtar
+++ b/encoding/gocode/testdata/comments.txtar
@@ -157,3 +157,41 @@ type Defaultchange struct {
 	} `json:"nested"`
 	S Struct `json:"s"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	// TODO docs
+	Astring *string `json:"astring,omitempty"`
+	N       struct {
+		// nested struct comment
+		Nested struct {
+			// AString struct comment
+			Astring *string `json:"astring,omitempty"`
+		} `json:"nested"`
+
+		// TODO docs
+		Test string `json:"test"`
+	} `json:"n"`
+	Nested struct {
+		N struct {
+			// nested struct comment
+			Nested struct {
+				// AString struct comment
+				Astring *string `json:"astring,omitempty"`
+			} `json:"nested"`
+
+			// TODO docs
+			Test string `json:"test"`
+		} `json:"n"`
+		S struct {
+			// AString struct comment
+			Astring *string `json:"astring,omitempty"`
+		} `json:"s"`
+	} `json:"nested"`
+	S struct {
+		// AString struct comment
+		Astring *string `json:"astring,omitempty"`
+	} `json:"s"`
+}

--- a/encoding/gocode/testdata/exemplar_defaultchange.txtar
+++ b/encoding/gocode/testdata/exemplar_defaultchange.txtar
@@ -61,6 +61,23 @@ type Defaultchange struct {
 
 // DefaultchangeAunion defines model for Defaultchange.Aunion.
 type DefaultchangeAunion string
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Defines values for DefaultchangeAunion.
+const (
+	DefaultchangeAunionBar DefaultchangeAunion = "bar"
+	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
+	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
+)
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Aunion DefaultchangeAunion `json:"aunion"`
+}
+
+// DefaultchangeAunion defines model for Defaultchange.Aunion.
+type DefaultchangeAunion string
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -108,6 +125,23 @@ type Defaultchange struct {
 // DefaultchangeAunion defines model for Defaultchange.Aunion.
 type DefaultchangeAunion string
 -- out/generate/1.0/godeclincomments.go --
+package defaultchange
+
+// Defines values for DefaultchangeAunion.
+const (
+	DefaultchangeAunionBar DefaultchangeAunion = "bar"
+	DefaultchangeAunionBaz DefaultchangeAunion = "baz"
+	DefaultchangeAunionFoo DefaultchangeAunion = "foo"
+)
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Aunion DefaultchangeAunion `json:"aunion"`
+}
+
+// DefaultchangeAunion defines model for Defaultchange.Aunion.
+type DefaultchangeAunion string
+-- out/generate/1.0/expandref.go --
 package defaultchange
 
 // Defines values for DefaultchangeAunion.

--- a/encoding/gocode/testdata/exemplar_disjunct.txtar
+++ b/encoding/gocode/testdata/exemplar_disjunct.txtar
@@ -21,6 +21,25 @@ package defaultchange
 type Disjunct struct {
 	Rootfield interface{} `json:"rootfield"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+import (
+	"encoding/json"
+)
+
+// Disjunct defines model for disjunct.
+type Disjunct struct {
+	Rootfield DisjunctRootfield `json:"rootfield"`
+}
+
+// DisjunctRootfield defines model for Disjunct.Rootfield.
+type DisjunctRootfield struct {
+	Branch    *interface{} `json:"branch,omitempty"`
+	Branchone *string      `json:"branchone,omitempty"`
+	Branchtwo *string      `json:"branchtwo,omitempty"`
+	union     json.RawMessage
+}
 -- out/generate/0.1/group.go --
 package defaultchange
 -- out/generate/0.1/nil.go --
@@ -43,4 +62,26 @@ package defaultchange
 // Disjunct defines model for disjunct.
 type Disjunct struct {
 	Rootfield interface{} `json:"rootfield"`
+}
+-- out/generate/0.1/expandref.go --
+package defaultchange
+
+import (
+	"encoding/json"
+)
+
+// Disjunct defines model for disjunct.
+type Disjunct struct {
+	Rootfield DisjunctRootfield `json:"rootfield"`
+}
+
+// DisjunctRootfield defines model for Disjunct.Rootfield.
+type DisjunctRootfield struct {
+	Branch      *interface{} `json:"branch,omitempty"`
+	Branchone   *string      `json:"branchone,omitempty"`
+	Branchthree *struct {
+		Branchthreeinner *interface{} `json:"branchthreeinner,omitempty"`
+	} `json:"branchthree,omitempty"`
+	Branchtwo *string `json:"branchtwo,omitempty"`
+	union     json.RawMessage
 }

--- a/encoding/gocode/testdata/exemplar_expand.txtar
+++ b/encoding/gocode/testdata/exemplar_expand.txtar
@@ -24,6 +24,13 @@ package defaultchange
 type Expand struct {
 	Init string `json:"init"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Expand defines model for expand.
+type Expand struct {
+	Init string `json:"init"`
+}
 -- out/generate/0.1/group.go --
 package defaultchange
 
@@ -49,6 +56,14 @@ type Expand struct {
 	Optional int    `json:"optional,omitempty"`
 }
 -- out/generate/0.1/godeclincomments.go --
+package defaultchange
+
+// Expand defines model for expand.
+type Expand struct {
+	Init     string `json:"init"`
+	Optional *int   `json:"optional,omitempty"`
+}
+-- out/generate/0.1/expandref.go --
 package defaultchange
 
 // Expand defines model for expand.
@@ -127,6 +142,24 @@ type Expand struct {
 
 // ExpandWithDefault defines model for Expand.WithDefault.
 type ExpandWithDefault string
+-- out/generate/0.2/expandref.go --
+package defaultchange
+
+// Defines values for ExpandWithDefault.
+const (
+	ExpandWithDefaultBar ExpandWithDefault = "bar"
+	ExpandWithDefaultFoo ExpandWithDefault = "foo"
+)
+
+// Expand defines model for expand.
+type Expand struct {
+	Init        string             `json:"init"`
+	Optional    *int               `json:"optional,omitempty"`
+	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+}
+
+// ExpandWithDefault defines model for Expand.WithDefault.
+type ExpandWithDefault string
 -- out/generate/0.3/group.go --
 package defaultchange
 
@@ -184,6 +217,25 @@ type Expand struct {
 // ExpandWithDefault defines model for Expand.WithDefault.
 type ExpandWithDefault string
 -- out/generate/0.3/godeclincomments.go --
+package defaultchange
+
+// Defines values for ExpandWithDefault.
+const (
+	ExpandWithDefaultBar ExpandWithDefault = "bar"
+	ExpandWithDefaultBaz ExpandWithDefault = "baz"
+	ExpandWithDefaultFoo ExpandWithDefault = "foo"
+)
+
+// Expand defines model for expand.
+type Expand struct {
+	Init        string             `json:"init"`
+	Optional    *int               `json:"optional,omitempty"`
+	WithDefault *ExpandWithDefault `json:"withDefault,omitempty"`
+}
+
+// ExpandWithDefault defines model for Expand.WithDefault.
+type ExpandWithDefault string
+-- out/generate/0.3/expandref.go --
 package defaultchange
 
 // Defines values for ExpandWithDefault.

--- a/encoding/gocode/testdata/exemplar_narrowing.txtar
+++ b/encoding/gocode/testdata/exemplar_narrowing.txtar
@@ -21,6 +21,13 @@ package defaultchange
 type Narrowing struct {
 	Boolish interface{} `json:"boolish"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Narrowing defines model for narrowing.
+type Narrowing struct {
+	Boolish interface{} `json:"boolish"`
+}
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -41,6 +48,13 @@ type Narrowing struct {
 	Properbool bool `json:"properbool"`
 }
 -- out/generate/1.0/godeclincomments.go --
+package defaultchange
+
+// Narrowing defines model for narrowing.
+type Narrowing struct {
+	Properbool bool `json:"properbool"`
+}
+-- out/generate/1.0/expandref.go --
 package defaultchange
 
 // Narrowing defines model for narrowing.

--- a/encoding/gocode/testdata/exemplar_rename.txtar
+++ b/encoding/gocode/testdata/exemplar_rename.txtar
@@ -30,6 +30,14 @@ type Rename struct {
 	Before    string `json:"before"`
 	Unchanged string `json:"unchanged"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Rename defines model for rename.
+type Rename struct {
+	Before    string `json:"before"`
+	Unchanged string `json:"unchanged"`
+}
 -- out/generate/1.0/group.go --
 package defaultchange
 
@@ -55,6 +63,14 @@ type Rename struct {
 	Unchanged string `json:"unchanged"`
 }
 -- out/generate/1.0/godeclincomments.go --
+package defaultchange
+
+// Rename defines model for rename.
+type Rename struct {
+	After     string `json:"after"`
+	Unchanged string `json:"unchanged"`
+}
+-- out/generate/1.0/expandref.go --
 package defaultchange
 
 // Rename defines model for rename.

--- a/encoding/gocode/testdata/exemplar_single.txtar
+++ b/encoding/gocode/testdata/exemplar_single.txtar
@@ -36,3 +36,12 @@ type Single struct {
 	Anint   int    `json:"anint"`
 	Astring string `json:"astring"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Single defines model for single.
+type Single struct {
+	Abool   bool   `json:"abool"`
+	Anint   int    `json:"anint"`
+	Astring string `json:"astring"`
+}

--- a/encoding/gocode/testdata/multi_type.txtar
+++ b/encoding/gocode/testdata/multi_type.txtar
@@ -130,3 +130,28 @@ type Generated struct {
 
 // Defaultchange defines model for defaultchange.
 type Defaultchange = map[string]interface{}
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Generated defines model for Generated.
+type Generated struct {
+	MultiType      interface{}                                    `json:"MultiType"`
+	DoubleList     [][]interface{}                                `json:"doubleList"`
+	EmptyStructs   [][]map[string]interface{}                     `json:"emptyStructs"`
+	ListMultiType  []interface{}                                  `json:"listMultiType"`
+	MapChained     map[string]map[string]interface{}              `json:"mapChained"`
+	MapDoubleList  map[string][][]interface{}                     `json:"mapDoubleList"`
+	MapList        map[string][]interface{}                       `json:"mapList"`
+	MapListChained map[string]map[string]map[string][]interface{} `json:"mapListChained"`
+	MapMultiType   map[string]interface{}                         `json:"mapMultiType"`
+	MapTripeList   map[string][][][]interface{}                   `json:"mapTripeList"`
+	NestedStruct   struct {
+		ListMultiType   []interface{}          `json:"listMultiType"`
+		MapMultiType    map[string]interface{} `json:"mapMultiType"`
+		StructMultiType interface{}            `json:"structMultiType"`
+	} `json:"nestedStruct"`
+	OptionalMultiType *interface{} `json:"optionalMultiType,omitempty"`
+}
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange = map[string]interface{}

--- a/encoding/gocode/testdata/pointers.txtar
+++ b/encoding/gocode/testdata/pointers.txtar
@@ -62,3 +62,13 @@ type Defaultchange struct {
 	Anint   *int     `json:"anint,omitempty"`
 	Astring *string  `json:"astring,omitempty"`
 }
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange struct {
+	Abool   *bool    `json:"abool,omitempty"`
+	Alist   []string `json:"alist,omitempty"`
+	Anint   *int     `json:"anint,omitempty"`
+	Astring *string  `json:"astring,omitempty"`
+}

--- a/encoding/gocode/testdata/underscores.txtar
+++ b/encoding/gocode/testdata/underscores.txtar
@@ -1,0 +1,157 @@
+-- in.cue --
+package generate
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "defaultchange"
+seqs: [
+        {
+            schemas: [
+                {
+				    #AType: {
+                        nestedType: #MultiNestedType
+                        optionalNestedType?: #MultiNestedType
+                    }
+
+                    #MultiNestedType: #SomeType | #SomeOtherType
+
+                    #SomeType: {
+                        astring: string
+                    }
+
+                    #SomeOtherType: {
+                        abool: bool
+                    }
+				},
+			]
+		},
+	]
+
+-- out/generate/0.0/group.go --
+package defaultchange
+
+// AType defines model for AType.
+type AType struct {
+	NestedType         interface{}  `json:"nestedType"`
+	OptionalNestedType *interface{} `json:"optionalNestedType,omitempty"`
+}
+
+// SomeOtherType defines model for SomeOtherType.
+type SomeOtherType struct {
+	Abool bool `json:"abool"`
+}
+
+// SomeType defines model for SomeType.
+type SomeType struct {
+	Astring string `json:"astring"`
+}
+-- out/generate/0.0/nil.go --
+package defaultchange
+
+// AType defines model for AType.
+type AType struct {
+	NestedType         interface{}  `json:"nestedType"`
+	OptionalNestedType *interface{} `json:"optionalNestedType,omitempty"`
+}
+
+// SomeOtherType defines model for SomeOtherType.
+type SomeOtherType struct {
+	Abool bool `json:"abool"`
+}
+
+// SomeType defines model for SomeType.
+type SomeType struct {
+	Astring string `json:"astring"`
+}
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange = map[string]interface{}
+-- out/generate/0.0/depointerized.go --
+package defaultchange
+
+// AType defines model for AType.
+type AType struct {
+	NestedType         interface{} `json:"nestedType"`
+	OptionalNestedType interface{} `json:"optionalNestedType,omitempty"`
+}
+
+// SomeOtherType defines model for SomeOtherType.
+type SomeOtherType struct {
+	Abool bool `json:"abool"`
+}
+
+// SomeType defines model for SomeType.
+type SomeType struct {
+	Astring string `json:"astring"`
+}
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange = map[string]interface{}
+-- out/generate/0.0/godeclincomments.go --
+package defaultchange
+
+// AType defines model for AType.
+type AType struct {
+	NestedType         interface{}  `json:"nestedType"`
+	OptionalNestedType *interface{} `json:"optionalNestedType,omitempty"`
+}
+
+// SomeOtherType defines model for SomeOtherType.
+type SomeOtherType struct {
+	Abool bool `json:"abool"`
+}
+
+// SomeType defines model for SomeType.
+type SomeType struct {
+	Astring string `json:"astring"`
+}
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange = map[string]interface{}
+-- out/generate/0.0/expandref.go --
+package defaultchange
+
+import (
+	"encoding/json"
+)
+
+// AType defines model for AType.
+type AType struct {
+	NestedType         ATypeNestedType          `json:"nestedType"`
+	OptionalNestedType *ATypeOptionalNestedType `json:"optionalNestedType,omitempty"`
+}
+
+// ATypeNestedType defines model for AType.NestedType.
+type ATypeNestedType struct {
+	Abool   *bool   `json:"abool,omitempty"`
+	Astring *string `json:"astring,omitempty"`
+	union   json.RawMessage
+}
+
+// ATypeOptionalNestedType defines model for AType.OptionalNestedType.
+type ATypeOptionalNestedType struct {
+	Abool   *bool   `json:"abool,omitempty"`
+	Astring *string `json:"astring,omitempty"`
+	union   json.RawMessage
+}
+
+// MultiNestedType defines model for MultiNestedType.
+type MultiNestedType struct {
+	Abool   *bool   `json:"abool,omitempty"`
+	Astring *string `json:"astring,omitempty"`
+	union   json.RawMessage
+}
+
+// SomeOtherType defines model for SomeOtherType.
+type SomeOtherType struct {
+	Abool bool `json:"abool"`
+}
+
+// SomeType defines model for SomeType.
+type SomeType struct {
+	Astring string `json:"astring"`
+}
+
+// Defaultchange defines model for defaultchange.
+type Defaultchange = map[string]interface{}

--- a/internal/txtartest/txtar.go
+++ b/internal/txtartest/txtar.go
@@ -392,8 +392,8 @@ func Load(a *txtar.Archive, dir string, args ...string) ([]*build.Instance, erro
 		mfs[f.Name] = &fstest.MapFile{Data: f.Data}
 	}
 
-	if _, has := mfs[filepath.Join("cue.mod", "module.cue")]; !has {
-		mfs[filepath.Join("cue.mod", "module.cue")] = &fstest.MapFile{Data: []byte(fmt.Sprintf("module: %q", testPath))}
+	if _, has := mfs["cue.mod/module.cue"]; !has {
+		mfs["cue.mod/module.cue"] = &fstest.MapFile{Data: []byte(fmt.Sprintf("module: %q", testPath))}
 	}
 
 	var insts []*build.Instance


### PR DESCRIPTION
Remove underscores in Go type names, as well as in the comment before the type and in references to these types.
Also fix a small issue running tests on Windows.

Fixes https://github.com/grafana/schematization-and-as-code-project/issues/66