### PR TITLE
Fix surface Less function and add tests

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -98,7 +98,14 @@ func (sch *UnarySchema) predecessor() *UnarySchema {
 // within this Schema's major version. If the receiver Schema is the latest, it
 // will return itself.
 func (sch *UnarySchema) LatestInMajor() Schema {
-	return sch.lin.allsch[searchSynv(sch.lin.allv, SyntacticVersion{sch.v[0] + 1, 0})]
+	n := searchSynv(sch.lin.allv, SyntacticVersion{sch.v[0] + 1, 0})
+
+	// If the next major version doesn't exist, n will be out of bound
+	if n == len(sch.lin.allsch) {
+		n -= 1
+	}
+
+	return sch.lin.allsch[n]
 }
 
 // Underlying returns the cue.Value that represents the underlying CUE schema.

--- a/surface.go
+++ b/surface.go
@@ -298,7 +298,11 @@ func SV(seqv, schv uint) SyntacticVersion {
 // Less reports whether the receiver [SyntacticVersion] is less than the
 // provided one, consistent with the expectations of the stdlib sort package.
 func (sv SyntacticVersion) Less(osv SyntacticVersion) bool {
-	return sv[0] < osv[0] || sv[1] < osv[1]
+	if sv[0] == osv[0] && sv[1] == osv[1] {
+		return false
+	}
+
+	return sv[0] <= osv[0] && sv[1] <= osv[1]
 }
 
 func (sv SyntacticVersion) String() string {

--- a/surface.go
+++ b/surface.go
@@ -298,11 +298,7 @@ func SV(seqv, schv uint) SyntacticVersion {
 // Less reports whether the receiver [SyntacticVersion] is less than the
 // provided one, consistent with the expectations of the stdlib sort package.
 func (sv SyntacticVersion) Less(osv SyntacticVersion) bool {
-	if sv[0] == osv[0] && sv[1] == osv[1] {
-		return false
-	}
-
-	return sv[0] <= osv[0] && sv[1] <= osv[1]
+	return sv[0] < osv[0] || (sv[0] == osv[0] && sv[1] < osv[1])
 }
 
 func (sv SyntacticVersion) String() string {

--- a/surface_test.go
+++ b/surface_test.go
@@ -1,6 +1,7 @@
 package thema
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,14 +18,16 @@ func TestLess(t *testing.T) {
 		{SV(0, 0), SV(1, 0), true},
 		{SV(0, 0), SV(1, 1), true},
 		{SV(0, 1), SV(0, 0), false},
-		{SV(0, 1), SV(1, 0), false},
+		{SV(0, 1), SV(1, 0), true},
 		{SV(1, 0), SV(0, 0), false},
 		{SV(1, 0), SV(0, 1), false},
 		{SV(1, 2), SV(0, 1), false},
 	}
 
 	for _, tc := range tests {
-		less := tc.v1.Less(tc.v2)
-		assert.Equal(t, tc.expected, less)
+		t.Run(fmt.Sprintf("comparison between %s and %s", tc.v1, tc.v2), func(t *testing.T) {
+			less := tc.v1.Less(tc.v2)
+			assert.Equal(t, tc.expected, less)
+		})
 	}
 }

--- a/surface_test.go
+++ b/surface_test.go
@@ -1,0 +1,30 @@
+package thema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLess(t *testing.T) {
+	var tests = []struct {
+		v1       SyntacticVersion
+		v2       SyntacticVersion
+		expected bool
+	}{
+		{SV(0, 0), SV(0, 0), false},
+		{SV(0, 0), SV(0, 1), true},
+		{SV(0, 0), SV(1, 0), true},
+		{SV(0, 0), SV(1, 1), true},
+		{SV(0, 1), SV(0, 0), false},
+		{SV(0, 1), SV(1, 0), false},
+		{SV(1, 0), SV(0, 0), false},
+		{SV(1, 0), SV(0, 1), false},
+		{SV(1, 2), SV(0, 1), false},
+	}
+
+	for _, tc := range tests {
+		less := tc.v1.Less(tc.v2)
+		assert.Equal(t, tc.expected, less)
+	}
+}


### PR DESCRIPTION
Fix `func (sv SyntacticVersion) Less(osv SyntacticVersion) bool` and add some tests for it and for related schema functions. 

Also fix `LatestInMajor` function that returns an out of range error if the next major version doesn't exist.