### PR TITLE
Fix oapi-codegen check

### DIFF
--- a/internal/deepmap/oapi-codegen/pkg/codegen/utils.go
+++ b/internal/deepmap/oapi-codegen/pkg/codegen/utils.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"go/token"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -904,5 +905,5 @@ func TypeDefinitionsEquivalent(t1, t2 TypeDefinition) bool {
 	if t1.TypeName != t2.TypeName {
 		return false
 	}
-	return t1.Schema.OAPISchema == t2.Schema.OAPISchema
+	return reflect.DeepEqual(t1.Schema.OAPISchema, t2.Schema.OAPISchema)
 }


### PR DESCRIPTION
`Oapi-codegen` was forked inside the library and it has a bug that it isn't able to detect that a duplicate field is the same. Mainly because its checking two pointers with equal operator.

This was reported and a PR was created in their repository to fix that bug.