### PR TITLE
fix(validate): fix order of fields in validation errors and tweak line placement

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -62,12 +62,12 @@ type twosidederr struct {
 func (e *twosidederr) Error() string {
 	var buf bytes.Buffer
 
-	fmt.Fprintf(&buf, "%s: validation failed, data is not an instance:\n\tschema expected `%s`", e.coords, e.sv)
+	fmt.Fprintf(&buf, "%s: validation failed, data is not an instance:\n\tschema expected `%s`", e.coords, e.dv)
 	for _, pos := range e.schpos {
 		fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
 	}
 
-	fmt.Fprintf(&buf, "\n\tbut data contained `%s`", e.dv)
+	fmt.Fprintf(&buf, "\n\tbut data contained `%s`", e.sv)
 	for _, pos := range e.datapos {
 		fmt.Fprintf(&buf, "\n\t\t%s", pos.String())
 	}
@@ -170,7 +170,7 @@ func mungeValidateErr(err error, sch Schema) error {
 		}
 
 		// We missed a case, wrap CUE err in a plea for help
-		errs = append(errs, fmt.Errorf("no Thema handler for CUE error, please file an issue against github.com/grafana/thema\nto improve this error output!\n\n%w", ee))
+		errs = append(errs, fmt.Errorf("no Thema handler for CUE error, please file an issue against github.com/grafana/thema\nto improve this error output:\n%w\n", ee))
 	}
 	return errs
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,1 +1,43 @@
 package thema
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+)
+
+// TODO: This is a very minimal test added to test a bug fix; please extend!
+func TestValidate(t *testing.T) {
+	lin := testLin()
+	sch, _ := lin.Schema(SyntacticVersion{0, 0})
+	ctx := cuecontext.New()
+	rt := NewRuntime(ctx)
+
+	tests := map[string]struct {
+		input   string
+		wantErr string
+	}{
+		"empty input": {
+			`{}`, "",
+		},
+		"invalid input - field not allowed": {
+			`{"cat": "cheetarah"}`, "no Thema handler for CUE error, please file an issue against github.com/grafana/thema\nto improve this error output:\n#Lineage._sortedSchemas.0._#schema.cat: field not allowed\n\n",
+		},
+		"invalid input - type mismatch": {
+			`{"abool": 42}`, "<single@v0.0>._sortedSchemas.0._#schema.abool: validation failed, data is not an instance:\n\tschema expected `42`\n\tbut data contained `bool`\n\t\t7:12\n\t\t1:11\n\t\t1:1\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			data := rt.Context().CompileString(test.input)
+			_, err := sch.Validate(data)
+			if test.wantErr != "" {
+				require.EqualError(t, err, test.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These are purely aesthetic changes to error messages returned by `Validate()`

Two changes in here:
* The "expected" and "contained" values in the "data is not an instance" errors were swapped; fixed.
* moved around the newlines in "no Thema handler for CUE error" so it was clear which error message that warning goes with. The placement of the newlines made it look like that message was following the previous error, instead of referring to the following error.

Before - note that the "no Thema handler" lines are part of the error message _below_ the newline
```
<dashboard@v0.1>._sortedSchemas.1._#schema.gnetId: validation failed, data is not an instance:
	schema expected `null`
		dashboard.json:18:13
		/scthema/dashboard_kind.cue:571:13
	but data contained `string`
		/scthema/cue.mod/pkg/github.com/grafana/thema/lineage.cue:258:20
no Thema handler for CUE error, please file an issue against github.com/grafana/thema
to improve this error output!

lineage._sortedSchemas.1._#schema.panels.0: 3 errors in empty disjunction:
no Thema handler for CUE error, please file an issue against github.com/grafana/thema
to improve this error output!

lineage._sortedSchemas.1._#schema.panels.0.animationModes: field not allowed
```

After:
```
<dashboard@v0.1>._sortedSchemas.1._#schema.gnetId: validation failed, data is not an instance:
	schema expected `string`
		dashboard.json:18:13
		/scthema/dashboard_kind.cue:571:13
	but data contained `null`
		/scthema/cue.mod/pkg/github.com/grafana/thema/lineage.cue:258:20
no Thema handler for CUE error, please file an issue against github.com/grafana/thema
to improve this error output:
lineage._sortedSchemas.1._#schema.panels.0: 3 errors in empty disjunction:


no Thema handler for CUE error, please file an issue against github.com/grafana/thema
to improve this error output:
lineage._sortedSchemas.1._#schema.panels.0.animationModes: field not allowed
```

I left the newlines after the "no Thema handler" message, but moved them to _after_ the error they were referencing; I think we would be better off removing all the extra newlines but I opted to stay closer to the existing implementation. I'm happy to change that. 

I added incredibly sad and minimal tests, nothing I'd write a full test suite - just enough to illustrate the changes. 