### PR TITLE
thema: Fix Translate() to same version

### DIFF
--- a/instance_test.go
+++ b/instance_test.go
@@ -1,14 +1,14 @@
-package thema_test
+package thema
 
 import (
+	"cuelang.org/go/cue"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
-	"github.com/grafana/thema"
-	"github.com/grafana/thema/internal/txtartest/bindlin"
 	"github.com/grafana/thema/internal/txtartest/vanilla"
-	"github.com/grafana/thema/vmux"
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/stretchr/testify/require"
@@ -21,41 +21,60 @@ func TestInstance_Translate(t *testing.T) {
 	}
 
 	ctx := cuecontext.New()
-	rt := thema.NewRuntime(ctx)
+	rt := NewRuntime(ctx)
 
 	test.Run(t, func(tc *vanilla.Test) {
 		if !tc.HasTag("multiversion") {
 			return
 		}
 
-		tName := strings.Replace(tc.Name(), t.Name()+"/", "", -1)
-
-		lin, lerr := bindlin.BindTxtarLineage(tc, rt)
+		lin, lerr := bindTxtarLineage(tc, rt)
 		require.NoError(tc, lerr)
 
 		for sch := lin.First(); sch != nil; sch = sch.Successor() {
-			for name, ex := range sch.Examples() {
+			for _, example := range sch.Examples() {
 				for sch := lin.First(); sch != nil; sch = sch.Successor() {
-					// TODO: Validate lacunas
 					to := sch.Version()
-					tinst, _ := ex.Translate(to)
+					tinst, lacunas := example.Translate(to)
 					require.NotNil(t, tinst)
 
-					raw := tinst.Underlying()
-					require.True(t, raw.Exists())
-					require.NoError(t, raw.Err())
+					result := tinst.Underlying()
+					require.True(t, result.Exists())
+					require.NoError(t, result.Err())
 
-					codec := vmux.NewJSONCodec("test")
-					rawBytes, err := codec.Encode(raw)
-					require.NoError(t, err)
-
-					wName := fmt.Sprintf("%s-%s-%s->%s.json", tName, name, ex.Schema().Version().String(), to.String())
-					w := tc.Writer(wName)
-					_, err = w.Write(rawBytes)
-					require.NoError(t, err)
+					writeGolden(tc, to, example, result, lacunas)
 				}
 			}
 		}
-
 	})
+}
+
+func writeGolden(tc *vanilla.Test, to SyntacticVersion, example *Instance, result cue.Value, lacunas TranslationLacunas) {
+	tc.Helper()
+
+	fromStr := example.Schema().Version().String()
+	toStr := to.String()
+
+	exName := example.name
+	tName := strings.Replace(tc.Name(), tc.Name()+"/", "", -1)
+	wName := fmt.Sprintf("%s-%s-%s->%s.json", tName, fromStr, exName, toStr)
+
+	w := tc.Writer(wName)
+
+	// From (example)
+	marshalAndWrite(tc, w, example.Underlying())
+	// To (result)
+	marshalAndWrite(tc, w, result)
+	// Lacunas
+	marshalAndWrite(tc, w, lacunas)
+}
+
+func marshalAndWrite(tc *vanilla.Test, w io.Writer, any interface{}) {
+	tc.Helper()
+
+	bytes, err := json.Marshal(any)
+	require.NoError(tc, err)
+
+	_, err = w.Write(append(bytes, '\n'))
+	require.NoError(tc, err)
 }

--- a/instance_test.go
+++ b/instance_test.go
@@ -1,0 +1,61 @@
+package thema_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/internal/txtartest/bindlin"
+	"github.com/grafana/thema/internal/txtartest/vanilla"
+	"github.com/grafana/thema/vmux"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstance_Translate(t *testing.T) {
+	test := vanilla.TxTarTest{
+		Root: "./testdata/lineage",
+		Name: "core/instance/translate",
+	}
+
+	ctx := cuecontext.New()
+	rt := thema.NewRuntime(ctx)
+
+	test.Run(t, func(tc *vanilla.Test) {
+		if !tc.HasTag("multiversion") {
+			return
+		}
+
+		tName := strings.Replace(tc.Name(), t.Name()+"/", "", -1)
+
+		lin, lerr := bindlin.BindTxtarLineage(tc, rt)
+		require.NoError(tc, lerr)
+
+		for sch := lin.First(); sch != nil; sch = sch.Successor() {
+			for name, ex := range sch.Examples() {
+				for sch := lin.First(); sch != nil; sch = sch.Successor() {
+					// TODO: Validate lacunas
+					to := sch.Version()
+					tinst, _ := ex.Translate(to)
+					require.NotNil(t, tinst)
+
+					raw := tinst.Underlying()
+					require.True(t, raw.Exists())
+					require.NoError(t, raw.Err())
+
+					codec := vmux.NewJSONCodec("test")
+					rawBytes, err := codec.Encode(raw)
+					require.NoError(t, err)
+
+					wName := fmt.Sprintf("%s-%s-%s->%s.json", tName, name, ex.Schema().Version().String(), to.String())
+					w := tc.Writer(wName)
+					_, err = w.Write(rawBytes)
+					require.NoError(t, err)
+				}
+			}
+		}
+
+	})
+}

--- a/testdata/internal/basic.cue
+++ b/testdata/internal/basic.cue
@@ -121,7 +121,7 @@ basic: #Lineage & {
 			from: [1, 1]
 			input: _
 			result: {
-				renamed: input.init
+				renamed: input.renamed
 				all:     input.all
 				if (input.optional != _|_) {
 					optional: input.optional

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -450,3 +450,1005 @@ lenses: [{
 Schema count: 6
 Schema versions: 0.0, 0.1, 0.2, 0.3, 1.0, 1.1
 Lenses count: 6
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== basicmultiversion_type_0.0_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init string `json:"init"`
+}
+== basicmultiversion_type_0.1_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init     string `json:"init"`
+	Optional *int32 `json:"optional,omitempty"`
+}
+== basicmultiversion_type_0.2_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_0.3_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.0_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.1_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar  BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz  BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultBing BasicmultiversionWithDefault = "bing"
+	BasicmultiversionWithDefaultFoo  BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+-- out/encoding/openapi/TestGenerate/nilcfg --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}== 0.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}== 0.2.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.2"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init",
+          "withDefault"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar"
+            ],
+            "default": "foo"
+          }
+        }
+      }
+    }
+  }
+}== 0.3.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.3"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init",
+          "withDefault"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar",
+              "baz"
+            ],
+            "default": "foo"
+          }
+        }
+      }
+    }
+  }
+}== 1.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "renamed",
+          "withDefault"
+        ],
+        "properties": {
+          "renamed": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "bar",
+              "foo",
+              "baz"
+            ],
+            "default": "bar"
+          }
+        }
+      }
+    }
+  }
+}== 1.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "renamed",
+          "withDefault"
+        ],
+        "properties": {
+          "renamed": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "bar",
+              "foo",
+              "baz",
+              "bing"
+            ],
+            "default": "bar"
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/gocode/TestGenerate/group --
+== basicmultiversion_type_0.0_gen.go
+package basicmultiversion
+
+// Init defines model for init.
+type Init = string
+== basicmultiversion_type_0.1_gen.go
+package basicmultiversion
+
+// Init defines model for init.
+type Init = string
+
+// Optional defines model for optional.
+type Optional = int32
+== basicmultiversion_type_0.2_gen.go
+package basicmultiversion
+
+// Defines values for WithDefault.
+const (
+	WithDefaultBar WithDefault = "bar"
+	WithDefaultFoo WithDefault = "foo"
+)
+
+// Init defines model for init.
+type Init = string
+
+// Optional defines model for optional.
+type Optional = int32
+
+// WithDefault defines model for withDefault.
+type WithDefault string
+== basicmultiversion_type_0.3_gen.go
+package basicmultiversion
+
+// Defines values for WithDefault.
+const (
+	WithDefaultBar WithDefault = "bar"
+	WithDefaultBaz WithDefault = "baz"
+	WithDefaultFoo WithDefault = "foo"
+)
+
+// Init defines model for init.
+type Init = string
+
+// Optional defines model for optional.
+type Optional = int32
+
+// WithDefault defines model for withDefault.
+type WithDefault string
+== basicmultiversion_type_1.0_gen.go
+package basicmultiversion
+
+// Defines values for WithDefault.
+const (
+	WithDefaultBar WithDefault = "bar"
+	WithDefaultBaz WithDefault = "baz"
+	WithDefaultFoo WithDefault = "foo"
+)
+
+// Optional defines model for optional.
+type Optional = int32
+
+// Renamed defines model for renamed.
+type Renamed = string
+
+// WithDefault defines model for withDefault.
+type WithDefault string
+== basicmultiversion_type_1.1_gen.go
+package basicmultiversion
+
+// Defines values for WithDefault.
+const (
+	WithDefaultBar  WithDefault = "bar"
+	WithDefaultBaz  WithDefault = "baz"
+	WithDefaultBing WithDefault = "bing"
+	WithDefaultFoo  WithDefault = "foo"
+)
+
+// Optional defines model for optional.
+type Optional = int32
+
+// Renamed defines model for renamed.
+type Renamed = string
+
+// WithDefault defines model for withDefault.
+type WithDefault string
+-- out/encoding/openapi/TestGenerate/group --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "init": {
+        "type": "string"
+      }
+    }
+  }
+}== 0.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "init": {
+        "type": "string"
+      },
+      "optional": {
+        "type": "integer",
+        "format": "int32"
+      }
+    }
+  }
+}== 0.2.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.2"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "init": {
+        "type": "string"
+      },
+      "optional": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "withDefault": {
+        "type": "string",
+        "enum": [
+          "foo",
+          "bar"
+        ],
+        "default": "foo"
+      }
+    }
+  }
+}== 0.3.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.3"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "init": {
+        "type": "string"
+      },
+      "optional": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "withDefault": {
+        "type": "string",
+        "enum": [
+          "foo",
+          "bar",
+          "baz"
+        ],
+        "default": "foo"
+      }
+    }
+  }
+}== 1.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "renamed": {
+        "type": "string"
+      },
+      "optional": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "withDefault": {
+        "type": "string",
+        "enum": [
+          "bar",
+          "foo",
+          "baz"
+        ],
+        "default": "bar"
+      }
+    }
+  }
+}== 1.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "renamed": {
+        "type": "string"
+      },
+      "optional": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "withDefault": {
+        "type": "string",
+        "enum": [
+          "bar",
+          "foo",
+          "baz",
+          "bing"
+        ],
+        "default": "bar"
+      }
+    }
+  }
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== basicmultiversion_type_0.0_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init string `json:"init"`
+}
+== basicmultiversion_type_0.1_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init     string `json:"init"`
+	Optional int32  `json:"optional,omitempty"`
+}
+== basicmultiversion_type_0.2_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    int32                        `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_0.3_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    int32                        `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.0_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    int32                        `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.1_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar  BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz  BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultBing BasicmultiversionWithDefault = "bing"
+	BasicmultiversionWithDefaultFoo  BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    int32                        `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+-- out/encoding/openapi/TestGenerate/expandrefs --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}== 0.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}== 0.2.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.2"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init",
+          "withDefault"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar"
+            ],
+            "default": "foo"
+          }
+        }
+      }
+    }
+  }
+}== 0.3.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "0.3"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "init",
+          "withDefault"
+        ],
+        "properties": {
+          "init": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar",
+              "baz"
+            ],
+            "default": "foo"
+          }
+        }
+      }
+    }
+  }
+}== 1.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "renamed",
+          "withDefault"
+        ],
+        "properties": {
+          "renamed": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "bar",
+              "foo",
+              "baz"
+            ],
+            "default": "bar"
+          }
+        }
+      }
+    }
+  }
+}== 1.1.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "basicmultiversion",
+    "version": "1.1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "basicmultiversion": {
+        "type": "object",
+        "required": [
+          "renamed",
+          "withDefault"
+        ],
+        "properties": {
+          "renamed": {
+            "type": "string"
+          },
+          "optional": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "withDefault": {
+            "type": "string",
+            "enum": [
+              "bar",
+              "foo",
+              "baz",
+              "bing"
+            ],
+            "default": "bar"
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== basicmultiversion_type_0.0_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init string `json:"init"`
+}
+== basicmultiversion_type_0.1_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init     string `json:"init"`
+	Optional *int32 `json:"optional,omitempty"`
+}
+== basicmultiversion_type_0.2_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_0.3_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.0_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.1_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar  BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz  BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultBing BasicmultiversionWithDefault = "bing"
+	BasicmultiversionWithDefaultFoo  BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+-- out/encoding/gocode/TestGenerate/expandref --
+== basicmultiversion_type_0.0_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init string `json:"init"`
+}
+== basicmultiversion_type_0.1_gen.go
+package basicmultiversion
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init     string `json:"init"`
+	Optional *int32 `json:"optional,omitempty"`
+}
+== basicmultiversion_type_0.2_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_0.3_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Init        string                       `json:"init"`
+	Optional    *int32                       `json:"optional,omitempty"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.0_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultFoo BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string
+== basicmultiversion_type_1.1_gen.go
+package basicmultiversion
+
+// Defines values for BasicmultiversionWithDefault.
+const (
+	BasicmultiversionWithDefaultBar  BasicmultiversionWithDefault = "bar"
+	BasicmultiversionWithDefaultBaz  BasicmultiversionWithDefault = "baz"
+	BasicmultiversionWithDefaultBing BasicmultiversionWithDefault = "bing"
+	BasicmultiversionWithDefaultFoo  BasicmultiversionWithDefault = "foo"
+)
+
+// Basicmultiversion defines model for basicmultiversion.
+type Basicmultiversion struct {
+	Optional    *int32                       `json:"optional,omitempty"`
+	Renamed     string                       `json:"renamed"`
+	WithDefault BasicmultiversionWithDefault `json:"withDefault"`
+}
+
+// BasicmultiversionWithDefault defines model for Basicmultiversion.WithDefault.
+type BasicmultiversionWithDefault string

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -7,10 +7,6 @@ import "github.com/grafana/thema"
 thema.#Lineage
 name: "basic-multiversion"
 
-joinSchema: {
-    all: int32
-}
-
 schemas: [{
     version: [0, 0]
     schema: {
@@ -18,7 +14,6 @@ schemas: [{
     }
     examples: {
         simple: {
-            all:  42
             init: "some string"
         }
     }
@@ -31,11 +26,9 @@ schemas: [{
     }
     examples: {
         withoutOptional: {
-            all:  42
             init: "some string"
         }
         withOptional: {
-            all:  42
             init: "some string"
             optional: 32
         }
@@ -50,12 +43,10 @@ schemas: [{
     }
     examples: {
         withoutOptional: {
-            all:  42
             init: "some string"
             withDefault: "foo"
         }
         withOptional: {
-            all:  42
             init: "some string"
             optional: 32
             withDefault: "bar"
@@ -71,12 +62,10 @@ schemas: [{
     }
     examples: {
         withoutOptional: {
-            all:  42
             init: "some string"
             withDefault: "baz"
         }
         withOptional: {
-            all:  42
             init: "some string"
             optional: 32
             withDefault: "baz"
@@ -92,12 +81,10 @@ schemas: [{
     }
     examples: {
         withoutOptional: {
-            all:  42
             renamed: "some string"
             withDefault: "foo"
         }
         withOptional: {
-            all:  42
             renamed: "some string"
             optional: 32
             withDefault: "bar"
@@ -113,12 +100,10 @@ schemas: [{
     }
     examples: {
         withoutOptional: {
-            all:  42
             renamed: "some string"
             withDefault: "bing"
         }
         withOptional: {
-            all:  42
             renamed: "some string"
             optional: 32
             withDefault: "bing"
@@ -132,7 +117,6 @@ lenses: [{
     input: _
     result: {
         init: input.renamed
-        all:  input.all
         if (input.optional != _|_) {
             optional: input.optional
         }
@@ -146,7 +130,6 @@ lenses: [{
     input: _
     result: {
         init: input.init
-        all:  input.all
         if (input.optional != _|_) {
             optional: input.optional
         }
@@ -158,7 +141,6 @@ lenses: [{
     input: _
     result: {
         init: input.init
-        all:  input.all
         if (input.optional != _|_) {
             optional: input.optional
         }
@@ -172,7 +154,6 @@ lenses: [{
     input: _
     result: {
         renamed: input.init
-        all:     input.all
         if (input.optional != _|_) {
             optional: input.optional
         }
@@ -186,7 +167,6 @@ lenses: [{
     input: _
     result: {
         renamed: input.renamed
-        all:     input.all
         if (input.optional != _|_) {
             optional: input.optional
         }
@@ -200,138 +180,5 @@ lenses: [{
     input: _
     result: {
         init: input.init
-        all:  input.all
     }
 }]
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.0.json --
-{"all":42,"init":"some string"}
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.1.json --
-{"all":42,"init":"some string"}
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.2.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.3.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->1.0.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->1.1.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.1.json --
-{"all":42,"init":"some string"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.2.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.3.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->1.0.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->1.1.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.1.json --
-{"all":42,"init":"some string","optional":32}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.2.json --
-{"all":42,"init":"some string","optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.3.json --
-{"all":42,"init":"some string","optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->1.0.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->1.1.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.1.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.2.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.3.json --
-{"all":42,"init":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->1.0.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->1.1.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.1.json --
-{"init":"some string","all":42,"optional":32}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.2.json --
-{"all":42,"init":"some string","optional":32,"withDefault":"bar"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.3.json --
-{"all":42,"init":"some string","optional":32,"withDefault":"bar"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->1.0.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->1.1.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.1.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.2.json --
-{"init":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.3.json --
-{"all":42,"init":"some string","withDefault":"baz"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->1.0.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->1.1.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.1.json --
-{"init":"some string","all":42,"optional":32}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.2.json --
-{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.3.json --
-{"all":42,"init":"some string","optional":32,"withDefault":"baz"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->1.0.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->1.1.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.1.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.2.json --
-{"init":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.3.json --
-{"init":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->1.0.json --
-{"all":42,"renamed":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->1.1.json --
-{"all":42,"renamed":"some string","withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.1.json --
-{"init":"some string","all":42,"optional":32}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.2.json --
-{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.3.json --
-{"init":"some string","all":42,"optional":32,"withDefault":"bar"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->1.0.json --
-{"all":42,"renamed":"some string","optional":32,"withDefault":"bar"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->1.1.json --
-{"all":42,"renamed":"some string","optional":32,"withDefault":"bar"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.1.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.2.json --
-{"init":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.3.json --
-{"init":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->1.0.json --
-{"renamed":"some string","all":42,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->1.1.json --
-{"all":42,"renamed":"some string","withDefault":"bing"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.0.json --
-{"init":"some string","all":42}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.1.json --
-{"init":"some string","all":42,"optional":32}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.2.json --
-{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.3.json --
-{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->1.0.json --
-{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
--- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->1.1.json --
-{"all":42,"renamed":"some string","optional":32,"withDefault":"bing"}

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -182,3 +182,271 @@ lenses: [{
         init: input.init
     }
 }]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.0.json --
+{"init":"some string"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.1.json --
+{"init":"some string"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.2.json --
+{"init":"some string"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.3.json --
+{"init":"some string"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->1.0.json --
+{"init":"some string"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->1.1.json --
+{"init":"some string"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->0.0.json --
+{"init":"some string"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->0.1.json --
+{"init":"some string"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->0.2.json --
+{"init":"some string"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->0.3.json --
+{"init":"some string"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->1.0.json --
+{"init":"some string"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withoutOptional->1.1.json --
+{"init":"some string"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->0.0.json --
+{"init":"some string","optional":32}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->0.1.json --
+{"init":"some string","optional":32}
+{"init":"some string","optional":32}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->0.2.json --
+{"init":"some string","optional":32}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->0.3.json --
+{"init":"some string","optional":32}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->1.0.json --
+{"init":"some string","optional":32}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.1-withOptional->1.1.json --
+{"init":"some string","optional":32}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->0.0.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->0.1.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->0.2.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32,"withDefault":"bar"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->0.3.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32,"withDefault":"bar"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->1.0.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withOptional->1.1.json --
+{"init":"some string","optional":32,"withDefault":"bar"}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->0.0.json --
+{"init":"some string","withDefault":"foo"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->0.1.json --
+{"init":"some string","withDefault":"foo"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->0.2.json --
+{"init":"some string","withDefault":"foo"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->0.3.json --
+{"init":"some string","withDefault":"foo"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->1.0.json --
+{"init":"some string","withDefault":"foo"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.2-withoutOptional->1.1.json --
+{"init":"some string","withDefault":"foo"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->0.0.json --
+{"init":"some string","withDefault":"baz"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->0.1.json --
+{"init":"some string","withDefault":"baz"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->0.2.json --
+{"init":"some string","withDefault":"baz"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->0.3.json --
+{"init":"some string","withDefault":"baz"}
+{"init":"some string","withDefault":"baz"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->1.0.json --
+{"init":"some string","withDefault":"baz"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withoutOptional->1.1.json --
+{"init":"some string","withDefault":"baz"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->0.0.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->0.1.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"init":"some string","optional":32}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->0.2.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->0.3.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"init":"some string","optional":32,"withDefault":"baz"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->1.0.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.3-withOptional->1.1.json --
+{"init":"some string","optional":32,"withDefault":"baz"}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->0.0.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->0.1.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->0.2.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->0.3.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"init":"some string","optional":32,"withDefault":"bar"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->1.0.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withOptional->1.1.json --
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+{"renamed":"some string","optional":32,"withDefault":"bar"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->0.0.json --
+{"renamed":"some string","withDefault":"foo"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->0.1.json --
+{"renamed":"some string","withDefault":"foo"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->0.2.json --
+{"renamed":"some string","withDefault":"foo"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->0.3.json --
+{"renamed":"some string","withDefault":"foo"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->1.0.json --
+{"renamed":"some string","withDefault":"foo"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.0-withoutOptional->1.1.json --
+{"renamed":"some string","withDefault":"foo"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->0.0.json --
+{"renamed":"some string","withDefault":"bing"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->0.1.json --
+{"renamed":"some string","withDefault":"bing"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->0.2.json --
+{"renamed":"some string","withDefault":"bing"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->0.3.json --
+{"renamed":"some string","withDefault":"bing"}
+{"init":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->1.0.json --
+{"renamed":"some string","withDefault":"bing"}
+{"renamed":"some string","withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withoutOptional->1.1.json --
+{"renamed":"some string","withDefault":"bing"}
+{"renamed":"some string","withDefault":"bing"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->0.0.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"init":"some string"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->0.1.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"init":"some string","optional":32}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->0.2.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->0.3.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"init":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->1.0.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"renamed":"some string","optional":32,"withDefault":"foo"}
+[]
+-- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-1.1-withOptional->1.1.json --
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+{"renamed":"some string","optional":32,"withDefault":"bing"}
+[]
+-- out/bind --
+Schema count: 6
+Schema versions: 0.0, 0.1, 0.2, 0.3, 1.0, 1.1
+Lenses count: 6

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -1,0 +1,337 @@
+# Basic schema evolution over time
+
+#multiversion
+-- in.cue --
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "basic-multiversion"
+
+joinSchema: {
+    all: int32
+}
+
+schemas: [{
+    version: [0, 0]
+    schema: {
+        init: string
+    }
+    examples: {
+        simple: {
+            all:  42
+            init: "some string"
+        }
+    }
+},
+{
+    version: [0, 1]
+    schema: {
+        init:      string
+        optional?: int32
+    }
+    examples: {
+        withoutOptional: {
+            all:  42
+            init: "some string"
+        }
+        withOptional: {
+            all:  42
+            init: "some string"
+            optional: 32
+        }
+    }
+},
+{
+    version: [0, 2]
+    schema: {
+        init:        string
+        optional?:   int32
+        withDefault: *"foo" | "bar"
+    }
+    examples: {
+        withoutOptional: {
+            all:  42
+            init: "some string"
+            withDefault: "foo"
+        }
+        withOptional: {
+            all:  42
+            init: "some string"
+            optional: 32
+            withDefault: "bar"
+        }
+    }
+},
+{
+    version: [0, 3]
+    schema: {
+        init:        string
+        optional?:   int32
+        withDefault: *"foo" | "bar" | "baz"
+    }
+    examples: {
+        withoutOptional: {
+            all:  42
+            init: "some string"
+            withDefault: "baz"
+        }
+        withOptional: {
+            all:  42
+            init: "some string"
+            optional: 32
+            withDefault: "baz"
+        }
+    }
+},
+{
+    version: [1, 0]
+    schema: {
+        renamed:     string
+        optional?:   int32
+        withDefault: "foo" | *"bar" | "baz"
+    }
+    examples: {
+        withoutOptional: {
+            all:  42
+            renamed: "some string"
+            withDefault: "foo"
+        }
+        withOptional: {
+            all:  42
+            renamed: "some string"
+            optional: 32
+            withDefault: "bar"
+        }
+    }
+},
+{
+    version: [1, 1]
+    schema: {
+        renamed:     string
+        optional?:   int32
+        withDefault: "foo" | *"bar" | "baz" | "bing"
+    }
+    examples: {
+        withoutOptional: {
+            all:  42
+            renamed: "some string"
+            withDefault: "bing"
+        }
+        withOptional: {
+            all:  42
+            renamed: "some string"
+            optional: 32
+            withDefault: "bing"
+        }
+    }
+}]
+
+lenses: [{
+    to: [0, 3]
+    from: [1, 0]
+    input: _
+    result: {
+        init: input.renamed
+        all:  input.all
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+
+        withDefault: input.withDefault
+    }
+},
+{
+    to: [0, 1]
+    from: [0, 2]
+    input: _
+    result: {
+        init: input.init
+        all:  input.all
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+    }
+},
+{
+    to: [0, 2]
+    from: [0, 3]
+    input: _
+    result: {
+        init: input.init
+        all:  input.all
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+        // TODO: withDefault: input.withDefault doesn't work
+        withDefault: "foo"
+    }
+},
+{
+    to: [1, 0]
+    from: [0, 3]
+    input: _
+    result: {
+        renamed: input.init
+        all:     input.all
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+        // TODO: withDefault: input.withDefault doesn't work
+        withDefault: "foo"
+    }
+},
+{
+    to: [1, 0]
+    from: [1, 1]
+    input: _
+    result: {
+        renamed: input.renamed
+        all:     input.all
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+        // TODO: withDefault: input.withDefault doesn't work
+        withDefault: "foo"
+    }
+},
+{
+    to: [0, 0]
+    from: [0, 1]
+    input: _
+    result: {
+        init: input.init
+        all:  input.all
+    }
+}]
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.0.json --
+{"all":42,"init":"some string"}
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.1.json --
+{"all":42,"init":"some string"}
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.2.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->0.3.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->1.0.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-simple-0.0->1.1.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.1.json --
+{"all":42,"init":"some string"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.2.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->0.3.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->1.0.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.1->1.1.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.1.json --
+{"all":42,"init":"some string","optional":32}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.2.json --
+{"all":42,"init":"some string","optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->0.3.json --
+{"all":42,"init":"some string","optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->1.0.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.1->1.1.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.1.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.2.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->0.3.json --
+{"all":42,"init":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->1.0.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.2->1.1.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.1.json --
+{"init":"some string","all":42,"optional":32}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.2.json --
+{"all":42,"init":"some string","optional":32,"withDefault":"bar"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->0.3.json --
+{"all":42,"init":"some string","optional":32,"withDefault":"bar"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->1.0.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.2->1.1.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.1.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.2.json --
+{"init":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->0.3.json --
+{"all":42,"init":"some string","withDefault":"baz"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->1.0.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-0.3->1.1.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.1.json --
+{"init":"some string","all":42,"optional":32}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.2.json --
+{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->0.3.json --
+{"all":42,"init":"some string","optional":32,"withDefault":"baz"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->1.0.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-0.3->1.1.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.1.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.2.json --
+{"init":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->0.3.json --
+{"init":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->1.0.json --
+{"all":42,"renamed":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.0->1.1.json --
+{"all":42,"renamed":"some string","withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.1.json --
+{"init":"some string","all":42,"optional":32}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.2.json --
+{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->0.3.json --
+{"init":"some string","all":42,"optional":32,"withDefault":"bar"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->1.0.json --
+{"all":42,"renamed":"some string","optional":32,"withDefault":"bar"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.0->1.1.json --
+{"all":42,"renamed":"some string","optional":32,"withDefault":"bar"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.1.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.2.json --
+{"init":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->0.3.json --
+{"init":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->1.0.json --
+{"renamed":"some string","all":42,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withoutOptional-1.1->1.1.json --
+{"all":42,"renamed":"some string","withDefault":"bing"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.0.json --
+{"init":"some string","all":42}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.1.json --
+{"init":"some string","all":42,"optional":32}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.2.json --
+{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->0.3.json --
+{"init":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->1.0.json --
+{"renamed":"some string","all":42,"optional":32,"withDefault":"foo"}
+-- out/core/instance/translate/lineage/basic-multiversion-withOptional-1.1->1.1.json --
+{"all":42,"renamed":"some string","optional":32,"withDefault":"bing"}

--- a/translate.cue
+++ b/translate.cue
@@ -125,7 +125,7 @@ import "list"
 				list.Drop(_accum, 1)
 			},
 			// to version same as from version is a no-op
-			if cmp == 0 {},
+			if cmp == 0 {[]},
 		][0]
 	}
 }


### PR DESCRIPTION
_(Descendant of https://github.com/grafana/thema/pull/141)_

It fixes the `Translate()` operation [when from and to versions are the same](https://github.com/grafana/thema/blob/main/translate.cue#L128), because the current implementation produces an error in such case:

```
_objold.steps: conflicting values [...#TranslatedInstance] and {} (mismatched types list and struct):
    ./testdata/internal/schmoo.cue:55:10
    ./translate.cue:37:10
    ./translate.cue:45:10
    ./translate.cue:128:16
```