### PR TITLE
corpus: Add two known failure cases

### DIFF
--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -21,6 +21,7 @@ func TestGenerate(t *testing.T) {
 			"lineage/defaultchange": "default backcompat invariants not working properly yet",
 			"lineage/optional":      "Optional fields do not satisfy struct.MinFields(), causing #Lineage constraints to fail",
 			"lineage/union":         "Test is abominably slow, cue evaluator is choking up on disjunctions",
+			"lineage/unifyref":      "CUE Struct unifications are not being properly rendered as Go struct embeddings",
 		},
 	}
 

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -58,6 +58,7 @@ func TestInvalidLineages(t *testing.T) {
 			"invalidlineage/defaultchange": "Thema compat analyzer fails to classify changes to default values as breaking",
 			"invalidlineage/joindef":       "no invariant checker written to disallow definitions from joinSchema",
 			"invalidlineage/onlydef":       "Lineage schema non-emptiness constraints are temporarily suspended while migrating grafana to flattened lineage structure",
+			"invalidlineage/addremove":     "Required field addition is not detected as breaking changes",
 		},
 	}
 

--- a/testdata/invalidlineage/addremove.txtar
+++ b/testdata/invalidlineage/addremove.txtar
@@ -1,0 +1,44 @@
+# adding or removing a required field is considered a backwards incompatible change
+#lineagePath: lin
+-- in.cue --
+
+import "github.com/grafana/thema"
+
+lin: thema.#Lineage
+lin: name: "breaking"
+lin: schemas: [{
+    version: [0, 0]
+    schema: {
+        firstfield: string
+    }
+},
+{
+    version: [0, 1]
+    schema: {
+        firstfield: string
+        added: int32
+    }
+},
+{
+    version: [0, 2]
+    schema: {
+        firstfield: string
+    }
+}]
+
+lin: lenses: [{
+	from: [0, 1]
+	to: [0, 0]
+	input: _
+	result: {
+		firstfield: input.firstfield
+	}
+}, {
+	from: [0, 2]
+	to: [0, 2]
+	input: _
+	result: {
+		firstfield: input.firstfield
+		secondfield: 42
+	}
+}]

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -1,6 +1,7 @@
 # Basic schema evolution over time
 
 #multiversion
+#slow
 -- in.cue --
 import "github.com/grafana/thema"
 

--- a/testdata/lineage/unifyref.txtar
+++ b/testdata/lineage/unifyref.txtar
@@ -1,0 +1,351 @@
+# schema contains an optional field with a ref to a type that references one type and extends another
+-- in.cue --
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "unifyref"
+schemas: [{
+	version: [0, 0]
+	schema: {
+	    afoo: #Foo
+
+	    #Foo: External & {
+	        optf?: #Bar
+	    }
+	    #Bar: {
+	        another: string
+	    }
+	}
+}]
+lenses: []
+
+External: {
+    extfield: string
+}
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== unifyref_type_0.0_gen.go
+package unifyref
+
+// Bar defines model for Bar.
+type Bar struct {
+	Another string `json:"another"`
+}
+
+// External defines model for External.
+type External struct {
+	Extfield string `json:"extfield"`
+}
+
+// Foo defines model for Foo.
+type Foo struct {
+	External
+	Optf     *Bar   `json:"optf,omitempty"`
+}
+
+// Unifyref defines model for unifyref.
+type Unifyref struct {
+	Afoo Foo `json:"afoo"`
+}
+-- out/encoding/gocode/TestGenerate/group --
+== unifyref_type_0.0_gen.go
+package unifyref
+
+// Bar defines model for Bar.
+type Bar struct {
+	Another string `json:"another"`
+}
+
+// External defines model for External.
+type External struct {
+	Extfield string `json:"extfield"`
+}
+
+// Foo defines model for Foo.
+type Foo struct {
+	External
+	Optf     *Bar   `json:"optf,omitempty"`
+}
+
+// Afoo defines model for afoo.
+type Afoo struct {
+	External
+	Optf     *Bar   `json:"optf,omitempty"`
+}
+-- out/encoding/openapi/TestGenerate/nilcfg --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unifyref",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Bar": {
+        "type": "object",
+        "required": [
+          "another"
+        ],
+        "properties": {
+          "another": {
+            "type": "string"
+          }
+        }
+      },
+      "External": {
+        "type": "object",
+        "required": [
+          "extfield"
+        ],
+        "properties": {
+          "extfield": {
+            "type": "string"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "optf": {
+            "$ref": "#/components/schemas/Bar"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/External"
+          }
+        ]
+      },
+      "unifyref": {
+        "type": "object",
+        "required": [
+          "afoo"
+        ],
+        "properties": {
+          "afoo": {
+            "$ref": "#/components/schemas/Foo"
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/group --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unifyref",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Bar": {
+        "type": "object",
+        "required": [
+          "another"
+        ],
+        "properties": {
+          "another": {
+            "type": "string"
+          }
+        }
+      },
+      "afoo": {
+        "type": "object",
+        "required": [
+          "extfield"
+        ],
+        "properties": {
+          "extfield": {
+            "type": "string"
+          },
+          "optf": {
+            "$ref": "#/components/schemas/Bar"
+          }
+        }
+      },
+      "External": {
+        "type": "object",
+        "required": [
+          "extfield"
+        ],
+        "properties": {
+          "extfield": {
+            "type": "string"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "properties": {
+          "optf": {
+            "$ref": "#/components/schemas/Bar"
+          }
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/External"
+          }
+        ]
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/expandrefs --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unifyref",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Bar": {
+        "type": "object",
+        "required": [
+          "another"
+        ],
+        "properties": {
+          "another": {
+            "type": "string"
+          }
+        }
+      },
+      "Foo": {
+        "type": "object",
+        "required": [
+          "extfield"
+        ],
+        "properties": {
+          "extfield": {
+            "type": "string"
+          },
+          "optf": {
+            "type": "object",
+            "required": [
+              "another"
+            ],
+            "properties": {
+              "another": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "unifyref": {
+        "type": "object",
+        "required": [
+          "afoo"
+        ],
+        "properties": {
+          "afoo": {
+            "type": "object",
+            "required": [
+              "extfield"
+            ],
+            "properties": {
+              "extfield": {
+                "type": "string"
+              },
+              "optf": {
+                "type": "object",
+                "required": [
+                  "another"
+                ],
+                "properties": {
+                  "another": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== unifyref_type_0.0_gen.go
+package unifyref
+
+// Bar defines model for Bar.
+type Bar struct {
+	Another string `json:"another"`
+}
+
+// External defines model for External.
+type External struct {
+	Extfield string `json:"extfield"`
+}
+
+// Foo defines model for Foo.
+type Foo struct {
+	External
+	Optf     Bar    `json:"optf,omitempty"`
+}
+
+// Unifyref defines model for unifyref.
+type Unifyref struct {
+	Afoo Foo `json:"afoo"`
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== unifyref_type_0.0_gen.go
+package unifyref
+
+// Bar defines model for Bar.
+type Bar struct {
+	Another string `json:"another"`
+}
+
+// External defines model for External.
+type External struct {
+	Extfield string `json:"extfield"`
+}
+
+// Foo defines model for Foo.
+type Foo struct {
+	External
+	Optf     *Bar   `json:"optf,omitempty"`
+}
+
+// Unifyref defines model for unifyref.
+type Unifyref struct {
+	Afoo Foo `json:"afoo"`
+}
+-- out/encoding/gocode/TestGenerate/expandref --
+== unifyref_type_0.0_gen.go
+package unifyref
+
+// Bar defines model for Bar.
+type Bar struct {
+	Another string `json:"another"`
+}
+
+// Foo defines model for Foo.
+type Foo struct {
+	External
+	Optf     *struct {
+		Another string `json:"another"`
+	} `json:"optf,omitempty"`
+}
+
+// Unifyref defines model for unifyref.
+type Unifyref struct {
+	Afoo struct {
+		Extfield string `json:"extfield"`
+		Optf     *struct {
+			Another string `json:"another"`
+		} `json:"optf,omitempty"`
+	} `json:"afoo"`
+}
+-- out/bind --
+Schema count: 1
+Schema versions: 0.0
+Lenses count: 0


### PR DESCRIPTION
This adds two known failure cases to the test corpus, and disables each case by marking them as `ToDo`:

* Adding a required field is not considered a backwards incompatible, so lineages are allowed to bind
* Go code generation does not embed or inline unified structs