### PR TITLE
thema: Try to return a concrete result from #Translate

### DIFF
--- a/instance.go
+++ b/instance.go
@@ -174,8 +174,10 @@ func (i *Instance) Translate(to SyntacticVersion) (*Instance, TranslationLacunas
 	lac := make(multiTranslationLacunas, 0)
 	out.LookupPath(cue.MakePath(cue.Str("lacunas"))).Decode(&lac)
 
+	raw, _ := out.LookupPath(cue.MakePath(cue.Str("result"), cue.Str("result"))).Default()
+
 	return &Instance{
-		raw:  out.LookupPath(cue.MakePath(cue.Str("result"), cue.Str("result"))),
+		raw:  raw,
 		name: i.name,
 		sch:  newsch,
 	}, lac

--- a/instance.go
+++ b/instance.go
@@ -174,6 +174,8 @@ func (i *Instance) Translate(to SyntacticVersion) (*Instance, TranslationLacunas
 	lac := make(multiTranslationLacunas, 0)
 	out.LookupPath(cue.MakePath(cue.Str("lacunas"))).Decode(&lac)
 
+	// Attempt to evaluate #Translate result into a concrete cue.Value, if possible.
+	// Otherwise, all the #Translate results are non-concrete, which leads to undesired effects.
 	raw, _ := out.LookupPath(cue.MakePath(cue.Str("result"), cue.Str("result"))).Default()
 
 	return &Instance{

--- a/instance_test.go
+++ b/instance_test.go
@@ -78,3 +78,59 @@ func marshalAndWrite(tc *vanilla.Test, w io.Writer, any interface{}) {
 	_, err = w.Write(append(bytes, '\n'))
 	require.NoError(tc, err)
 }
+
+// TestInstance_LookupPathOnTranslatedInstance is a regression test
+// specifically written for https://github.com/grafana/thema/issues/155.
+//
+// Caused because [Instance.Translate] results were always non-concrete,
+// when the result evaluates to something concrete.
+//
+// So, this test checks that [cue.Value.LookupPath] behaves as expected
+// when used over an [Instance.Translate] result.
+func TestInstance_LookupPathOnTranslatedInstance(t *testing.T) {
+	ctx := cuecontext.New()
+	rt := NewRuntime(ctx)
+
+	// Initialize lineage for testing
+	linstr := `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: string
+		},
+	},
+	{
+		version: [0, 1]
+		schema:
+		{
+			title: string
+			header?: string
+		},
+	},
+]`
+	linval := rt.Context().CompileString(linstr)
+	lin, err := BindLineage(linval, rt)
+	require.NoError(t, err)
+
+	// Initialize cue.Value
+	expected := "foo"
+	val := ctx.CompileString(fmt.Sprintf(`{"title": "%s"}`, expected))
+
+	// Validate cue.Value
+	inst := lin.ValidateAny(val)
+	require.Equal(t, SV(0, 0), inst.Schema().Version())
+
+	got, err := inst.Underlying().LookupPath(cue.ParsePath("title")).String()
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+
+	// Translate cue.Value (no lacunas)
+	tinst, _ := inst.Translate(SV(0, 1))
+	require.Equal(t, SV(0, 0), inst.Schema().Version())
+
+	got, err = tinst.Underlying().LookupPath(cue.ParsePath("title")).String()
+	require.NoError(t, err)
+	require.Equal(t, expected, got)
+}


### PR DESCRIPTION
It adds a call to `Default()` after calling the CUE `#Translate` to try to return a concrete result, and deal with inconsistently-shaped instances from `Translate` and `Validate`, as described in #155.

It also adds a regression test specifically checking what's described on the issue. 

Fixes #155 