### PR TITLE
Example to attach Thema to Unity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,10 @@
+name: CUE Unity Test
+
 on:
   push:
     branches:
-      - main
-    tags:
-      - v*
-  pull_request:
-    branches:
       - '**'
-name: Test
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,4 +23,4 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v3
-        run: go run github.com/cue-unity/unity/cmd/unity test --verbose
+      - run: go run github.com/cue-unity/unity/cmd/unity test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,5 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v3
-      - run: |
-          go install github.com/cue-unity/unity/cmd/unity@latest
-          unity test --verbose
+      - run: go install github.com/cue-unity/unity/cmd/unity@latest
+      - run: unity test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.20']
+        go-version: ['1.19']
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -21,5 +21,5 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - run: |
-          go install github.com/cue-unity/unity/cmd/unity
+          go install github.com/cue-unity/unity/cmd/unity@latest
           unity test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v3
-      - run: go run github.com/cue-unity/unity/cmd/unity test --verbose
+      - run: |
+          go install github.com/cue-unity/unity/cmd/unity
+          unity test --verbose

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+  pull_request:
+    branches:
+      - '**'
+name: Test
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.20']
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v3
+        run: go run github.com/cue-unity/unity/cmd/unity test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 .idea
 
 cmd/thema/thema
+
+# Output from cue-unity
+/.unity-bin

--- a/cue.mod/tests/foo.txt
+++ b/cue.mod/tests/foo.txt
@@ -1,0 +1,9 @@
+# Verify that eval works as expect
+
+cue eval $WORK/repo/testdata/foo.cue
+cmp stdout $WORK/stdout.golden
+
+-- stdout.golden --
+renamed:     "i'mma string"
+all:         99999
+withDefault: "foo" | "bar"

--- a/cue.mod/tests/tests.cue
+++ b/cue.mod/tests/tests.cue
@@ -1,0 +1,3 @@
+package tests
+
+Versions: ["go.mod", "v0.5.0"]

--- a/testdata/foo.cue
+++ b/testdata/foo.cue
@@ -1,0 +1,13 @@
+package schmoo
+
+import "github.com/grafana/thema/testdata/internal:thema"
+
+(thema.#Translate & {
+	lin:  thema.basic
+	inst: {
+		all:  99999
+		init: "i'mma string"
+	}
+	from: [0, 0]
+	to: [1, 0]
+}).out.result.result

--- a/testdata/foo.cue
+++ b/testdata/foo.cue
@@ -5,7 +5,7 @@ import "github.com/grafana/thema/testdata/internal:thema"
 (thema.#Translate & {
 	lin:  thema.basic
 	inst: {
-		all:  99999
+		all:  88888
 		init: "i'mma string"
 	}
 	from: [0, 0]


### PR DESCRIPTION
Example for #121:
- It defines the manifest as described at https://github.com/cue-unity/unity:
  - Look at `cue.mod/tests/tests.cue`.
- Adds a `foo.cue` file as an example of "test" (some CUE code to evaluate).
- Adds a `foo.txt` as a `testscript` definition, that `cue eval` the `foo.cue` file and compares the output.
- Adds a GitHub Action workflow to run `unity test` on the repository (project mode).