### PR TITLE
thema: Remove native CUE sorting for drastic performance boost

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -44,7 +44,6 @@ type maybeLineage struct {
 }
 
 func (ml *maybeLineage) checkGoValidity(cfg *bindConfig) error {
-	// schiter, err := ml.uni.LookupPath(cue.MakePath(cue.Hid("_sortedSchemas", "github.com/grafana/thema"))).List()
 	schiter, err := ml.uni.LookupPath(cue.MakePath(cue.Str("schemas"))).List()
 	if err != nil {
 		panic(fmt.Sprintf("unreachable - should have already verified schemas field exists and is list: %+v", cerrors.Details(err, nil)))

--- a/bind.go
+++ b/bind.go
@@ -44,7 +44,8 @@ type maybeLineage struct {
 }
 
 func (ml *maybeLineage) checkGoValidity(cfg *bindConfig) error {
-	schiter, err := ml.uni.LookupPath(cue.MakePath(cue.Hid("_sortedSchemas", "github.com/grafana/thema"))).List()
+	// schiter, err := ml.uni.LookupPath(cue.MakePath(cue.Hid("_sortedSchemas", "github.com/grafana/thema"))).List()
+	schiter, err := ml.uni.LookupPath(cue.MakePath(cue.Str("schemas"))).List()
 	if err != nil {
 		panic(fmt.Sprintf("unreachable - should have already verified schemas field exists and is list: %+v", cerrors.Details(err, nil)))
 	}

--- a/exemplars/exemplars_test.go
+++ b/exemplars/exemplars_test.go
@@ -36,15 +36,3 @@ func TestExemplarValidity(t *testing.T) {
 		})
 	}
 }
-
-func BenchmarkBindLineage(b *testing.B) {
-	for name, o := range nameOpts {
-		b.Run(name, func(b *testing.B) {
-			lib := thema.NewRuntime(cuecontext.New())
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				lineageForExemplar(name, lib, o...)
-			}
-		})
-	}
-}

--- a/lineage.cue
+++ b/lineage.cue
@@ -61,14 +61,14 @@ import (
 	// Thus, for a lineage with schema versions [0,0], [0,1], [1,0], [2,0], [2,1],
 	// the following lenses must exist (implicit lenses are wrapped in parentheses):
 	//
-	// ([0,0] -> [0,1])
 	//  [0,1] -> [0,0]
-	//  [0,1] -> [1,0]
+	// ([0,0] -> [0,1])
 	//  [1,0] -> [0,1]
-	//  [1,0] -> [2,0]
+	//  [0,1] -> [1,0]
 	//  [2,0] -> [1,0]
-	// ([2,0] -> [2,1])
+	//  [1,0] -> [2,0]
 	//  [2,1] -> [2,0]
+	// ([2,0] -> [2,1])
 	//
 	// To be valid, a lineage must define the exact set of explicit lenses entailed by its
 	// set of schema versions. It is not permitted to explicitly define a lens across
@@ -79,7 +79,7 @@ import (
 	// list. Thema tooling that modifies and emits lineages definitions may produce lenses
 	// sorted in ascending order, rather than original source order.
 	// TODO switch to descending order - newest on top is nicer to read
-	lenses: [...#Lens]
+	SL=lenses: [...#Lens]
 
 	_atLeastOneSchema: len(schemas) > 0
 
@@ -92,21 +92,8 @@ import (
 		_schemas: [#SchemaDef & {version: [0, 0]}]
 	}
 
-	//	SS=_sortedSchemas: list.Sort(_schemas, {
-	//		x:    #SchemaDef
-	//		y:    #SchemaDef
-	//		less: (_cmpSV & {l: x.version, r: y.version}).out == -1
-	//	}) & list.MinItems(1)
-
-	// TODO add informative validation that exactly the expected set of explicit lenses exist
-	_sortedLenses: list.Sort(lenses, {
-		x:    #Lens
-		y:    #Lens
-		less: ((_cmpSV & {l: x.to, r: y.to}).out == -1 || (x.to == y.to && x.from[0] < y.from[0]))
-	})
-
-	_forwardLenses: [ for lens in _sortedLenses if {lens.to[0] > lens.from[0]} {lens}]
-	_backwardLenses: [ for lens in _sortedLenses if {lens.to[0] <= lens.from[0]} {lens}]
+	_forwardLenses: [ for lens in SL if {lens.to[0] > lens.from[0]} {lens}]
+	_backwardLenses: [ for lens in SL if {lens.to[0] <= lens.from[0]} {lens}]
 
 	// preserved for debugging
 	//	lensVersions: {

--- a/lineage.cue
+++ b/lineage.cue
@@ -83,19 +83,20 @@ import (
 
 	_atLeastOneSchema: len(schemas) > 0
 
-	_schemas: [...]
+	SS=_schemas: [...]
 	if _atLeastOneSchema == true {
 		_schemas: schemas
 	}
+
 	if _atLeastOneSchema == false {
 		_schemas: [#SchemaDef & {version: [0, 0]}]
 	}
 
-	SS=_sortedSchemas: list.Sort(_schemas, {
-		x:    #SchemaDef
-		y:    #SchemaDef
-		less: (_cmpSV & {l: x.version, r: y.version}).out == -1
-	}) & list.MinItems(1)
+	//	SS=_sortedSchemas: list.Sort(_schemas, {
+	//		x:    #SchemaDef
+	//		y:    #SchemaDef
+	//		less: (_cmpSV & {l: x.version, r: y.version}).out == -1
+	//	}) & list.MinItems(1)
 
 	// TODO add informative validation that exactly the expected set of explicit lenses exist
 	_sortedLenses: list.Sort(lenses, {

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -35,8 +35,9 @@ func TestBindLineage(t *testing.T) {
 		if err != nil {
 			tc.Fatalf("error binding lineage: %+v", err)
 		}
-
-		sspath := cue.MakePath(cue.Hid("_sortedSchemas", "github.com/grafana/thema"))
+		// schemaselem := cue.Hid("_sortedSchemas", "github.com/grafana/thema")
+		schemaselem := cue.Str("schemas")
+		sspath := cue.MakePath(schemaselem)
 		slen, err := lin.Underlying().LookupPath(sspath).Len().Int64()
 		if err != nil {
 			tc.Fatal("error getting schemas len", err)

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -35,7 +35,6 @@ func TestBindLineage(t *testing.T) {
 		if err != nil {
 			tc.Fatalf("error binding lineage: %+v", err)
 		}
-		// schemaselem := cue.Hid("_sortedSchemas", "github.com/grafana/thema")
 		schemaselem := cue.Str("schemas")
 		sspath := cue.MakePath(schemaselem)
 		slen, err := lin.Underlying().LookupPath(sspath).Len().Int64()
@@ -45,7 +44,6 @@ func TestBindLineage(t *testing.T) {
 		fmt.Fprintf(tc, "Schema count: %v\n", slen)
 		fmt.Fprintf(tc, "Schema versions: %s\n", lin.allVersions())
 
-		// lenseselem := cue.Hid("_sortedLenses", "github.com/grafana/thema")
 		var llen int64
 		if slen > 1 {
 			lenseselem := cue.Str("lenses")

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -45,7 +45,9 @@ func TestBindLineage(t *testing.T) {
 		fmt.Fprintf(tc, "Schema count: %v\n", slen)
 		fmt.Fprintf(tc, "Schema versions: %s\n", lin.allVersions())
 
-		slpath := cue.MakePath(cue.Hid("_sortedLenses", "github.com/grafana/thema"))
+		// lenseselem := cue.Hid("_sortedLenses", "github.com/grafana/thema")
+		lenseselem := cue.Str("lenses")
+		slpath := cue.MakePath(lenseselem)
 		llen, err := lin.Underlying().LookupPath(slpath).Len().Int64()
 		if err != nil {
 			tc.Fatal("error getting schemas len", err)

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -46,11 +46,14 @@ func TestBindLineage(t *testing.T) {
 		fmt.Fprintf(tc, "Schema versions: %s\n", lin.allVersions())
 
 		// lenseselem := cue.Hid("_sortedLenses", "github.com/grafana/thema")
-		lenseselem := cue.Str("lenses")
-		slpath := cue.MakePath(lenseselem)
-		llen, err := lin.Underlying().LookupPath(slpath).Len().Int64()
-		if err != nil {
-			tc.Fatal("error getting schemas len", err)
+		var llen int64
+		if slen > 1 {
+			lenseselem := cue.Str("lenses")
+			slpath := cue.MakePath(lenseselem)
+			llen, err = lin.Underlying().LookupPath(slpath).Len().Int64()
+			if err != nil {
+				tc.Fatal("error getting lenses len", err)
+			}
 		}
 		fmt.Fprintf(tc, "Lenses count: %v\n", llen)
 	})

--- a/testdata/invalidlineage/empty-schemas.txtar
+++ b/testdata/invalidlineage/empty-schemas.txtar
@@ -7,7 +7,3 @@ name: "empty-schemas"
 schemas: []
 -- out/bindfail --
 incompatible list lengths (0 and 1)
-_sortedSchemas: invalid value [] (does not satisfy list.MinItems(1)): len(list) < MinItems(1) (0 < 1):
-    ../../lineage.cue:98:7
-    ../../lineage.cue:94:21
-    ../../lineage.cue:98:21

--- a/testdata/invalidlineage/second-schema-versionless.txtar
+++ b/testdata/invalidlineage/second-schema-versionless.txtar
@@ -32,8 +32,8 @@ lenses: [
 ]
 -- out/bindfail --
 _schemasAreOrdered.1: conflicting values true and false:
-    ../../lineage.cue:126:3
-    ../../lineage.cue:127:4
-    ../../lineage.cue:132:5
-    ../../lineage.cue:133:11
+    ../../lineage.cue:113:3
+    ../../lineage.cue:114:4
+    ../../lineage.cue:119:5
+    ../../lineage.cue:120:11
     ./in.cue:4:1

--- a/testdata/invalidlineage/second-schema-versionless.txtar
+++ b/testdata/invalidlineage/second-schema-versionless.txtar
@@ -32,8 +32,8 @@ lenses: [
 ]
 -- out/bindfail --
 _schemasAreOrdered.1: conflicting values true and false:
-    ../../lineage.cue:125:3
-    ../../lineage.cue:126:4
-    ../../lineage.cue:131:5
-    ../../lineage.cue:132:11
+    ../../lineage.cue:126:3
+    ../../lineage.cue:127:4
+    ../../lineage.cue:132:5
+    ../../lineage.cue:133:11
     ./in.cue:4:1

--- a/testdata/isappendonly/invalid/boundaries.txtar
+++ b/testdata/isappendonly/invalid/boundaries.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field anInt not present in {anInt:*12 | >0 & <=24 & int}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:7:10
 missing field "anInt"

--- a/testdata/isappendonly/invalid/boundaries.txtar
+++ b/testdata/isappendonly/invalid/boundaries.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field anInt not present in {anInt:*12 | >0 & <=24 & int}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:7:10
 missing field "anInt"

--- a/testdata/isappendonly/invalid/default.txtar
+++ b/testdata/isappendonly/invalid/default.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aunion not present in {aunion:*"bar" | "foo" | "baz"}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:16:13
 missing field "aunion"

--- a/testdata/isappendonly/invalid/default.txtar
+++ b/testdata/isappendonly/invalid/default.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aunion not present in {aunion:*"bar" | "foo" | "baz"}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:16:13
 missing field "aunion"

--- a/testdata/isappendonly/invalid/embedref.txtar
+++ b/testdata/isappendonly/invalid/embedref.txtar
@@ -32,7 +32,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #EmbedRef not present in {#EmbedRef:{refField1:string,refField2:1},refField1:string,refField2:1}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:21:13
 field refField2 not present in {refField1:string,refField2:1}:
     ./in.cue:24:20

--- a/testdata/isappendonly/invalid/embedref.txtar
+++ b/testdata/isappendonly/invalid/embedref.txtar
@@ -32,7 +32,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #EmbedRef not present in {#EmbedRef:{refField1:string,refField2:1},refField1:string,refField2:1}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:21:13
 field refField2 not present in {refField1:string,refField2:1}:
     ./in.cue:24:20

--- a/testdata/isappendonly/invalid/nested.txtar
+++ b/testdata/isappendonly/invalid/nested.txtar
@@ -29,6 +29,6 @@ lin2: schemas: [{
 field aNewOptionalField not present in {aField:string}:
     ./in.cue:8:13
 field anObject not present in {anObject:{aField:string}}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:7:10
 missing field "anObject"

--- a/testdata/isappendonly/invalid/nested.txtar
+++ b/testdata/isappendonly/invalid/nested.txtar
@@ -26,8 +26,9 @@ lin2: schemas: [{
     }
 }]
 -- out/isappendonly-fail --
+field aNewOptionalField not present in {aField:string}:
+    ./in.cue:8:13
 field anObject not present in {anObject:{aField:string}}:
-    ../../../lineage.cue:247:10
-    ./in.cue:18:13
-field not allowed in closed struct: aNewOptionalField
+    ../../../lineage.cue:248:10
+    ./in.cue:7:10
 missing field "anObject"

--- a/testdata/isappendonly/invalid/newfield.txtar
+++ b/testdata/isappendonly/invalid/newfield.txtar
@@ -22,5 +22,5 @@ lin2: schemas: [{
     }
 }]
 -- out/isappendonly-fail --
-field not allowed in closed struct: secondfield
+required field is optional in subsumed value: secondfield
 value not an instance

--- a/testdata/isappendonly/invalid/noref.txtar
+++ b/testdata/isappendonly/invalid/noref.txtar
@@ -34,7 +34,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #Baz not present in {someField:string,#Baz:{run:string,tell:bytes}}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:22:13
 missing field "#Baz"
 required field is optional in subsumed value: dat

--- a/testdata/isappendonly/invalid/noref.txtar
+++ b/testdata/isappendonly/invalid/noref.txtar
@@ -34,7 +34,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #Baz not present in {someField:string,#Baz:{run:string,tell:bytes}}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:22:13
 missing field "#Baz"
 required field is optional in subsumed value: dat

--- a/testdata/isappendonly/invalid/optional.txtar
+++ b/testdata/isappendonly/invalid/optional.txtar
@@ -23,6 +23,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aNewOptionalField not present in {aField:string}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:7:10
 missing field "aNewOptionalField"

--- a/testdata/isappendonly/invalid/optional.txtar
+++ b/testdata/isappendonly/invalid/optional.txtar
@@ -22,5 +22,7 @@ lin2: schemas: [{
     }
 }]
 -- out/isappendonly-fail --
-field not allowed in closed struct: aNewOptionalField
-value not an instance
+field aNewOptionalField not present in {aField:string}:
+    ../../../lineage.cue:248:10
+    ./in.cue:7:10
+missing field "aNewOptionalField"

--- a/testdata/isappendonly/invalid/refstruct.txtar
+++ b/testdata/isappendonly/invalid/refstruct.txtar
@@ -33,7 +33,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aBaz not present in {aBaz:{run:string,dat:>=-2147483648 & <=2147483647 & int},#Baz:{run:string,dat:>=-2147483648 & <=2147483647 & int}}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:22:13
 missing field "aBaz"
 required field is optional in subsumed value: tell

--- a/testdata/isappendonly/invalid/refstruct.txtar
+++ b/testdata/isappendonly/invalid/refstruct.txtar
@@ -33,7 +33,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aBaz not present in {aBaz:{run:string,dat:>=-2147483648 & <=2147483647 & int},#Baz:{run:string,dat:>=-2147483648 & <=2147483647 & int}}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:22:13
 missing field "aBaz"
 required field is optional in subsumed value: tell

--- a/testdata/isappendonly/invalid/stringconstraint.txtar
+++ b/testdata/isappendonly/invalid/stringconstraint.txtar
@@ -35,7 +35,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aString not present in {aString:strings.MinRunes(2),anObject:{aField:int}}:
-    ../../../lineage.cue:248:10
+    ../../../lineage.cue:235:10
     ./in.cue:25:10
 missing field "aString"
 invalid value strings.MinRunes(2) (does not satisfy strings.MinRunes(1)): error in call to strings.MinRunes: non-concrete value string:

--- a/testdata/isappendonly/invalid/stringconstraint.txtar
+++ b/testdata/isappendonly/invalid/stringconstraint.txtar
@@ -35,7 +35,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aString not present in {aString:strings.MinRunes(2),anObject:{aField:int}}:
-    ../../../lineage.cue:247:10
+    ../../../lineage.cue:248:10
     ./in.cue:25:10
 missing field "aString"
 invalid value strings.MinRunes(2) (does not satisfy strings.MinRunes(1)): error in call to strings.MinRunes: non-concrete value string:

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -138,16 +138,11 @@ schemas: [{
 }]
 
 lenses: [{
-    to: [0, 3]
-    from: [1, 0]
+    to: [0, 0]
+    from: [0, 1]
     input: _
     result: {
-        init: input.renamed
-        if (input.optional != _|_) {
-            optional: input.optional
-        }
-
-        withDefault: input.withDefault
+        init: input.init
     }
 },
 {
@@ -175,6 +170,19 @@ lenses: [{
     }
 },
 {
+    to: [0, 3]
+    from: [1, 0]
+    input: _
+    result: {
+        init: input.renamed
+        if (input.optional != _|_) {
+            optional: input.optional
+        }
+
+        withDefault: input.withDefault
+    }
+},
+{
     to: [1, 0]
     from: [0, 3]
     input: _
@@ -198,14 +206,6 @@ lenses: [{
         }
         // TODO: withDefault: input.withDefault doesn't work
         withDefault: "foo"
-    }
-},
-{
-    to: [0, 0]
-    from: [0, 1]
-    input: _
-    result: {
-        init: input.init
     }
 },
 {

--- a/translate.cue
+++ b/translate.cue
@@ -24,7 +24,7 @@ import "list"
 //
 // TODO functionize
 #Translate: {
-	L=lin: #Lineage
+	L=lin: _
 	I=inst: {...}
 	FV=from: #SyntacticVersion
 	TV=to:   #SyntacticVersion
@@ -55,7 +55,7 @@ import "list"
 					let prior = _accum[i]
 
 					// the actual schema def
-					let schdef = L._sortedSchemas[pos]
+					let schdef = L.schemas[pos]
 
 					// TODO does having this field in the result, even hidden, cause a problem? does using an alias cause the computation to run more than once?
 					_lens: L._backwardLenses[(L._flatidx & {v: schdef.version}).out] & {
@@ -84,7 +84,7 @@ import "list"
 				// translation, inclusive of the starting schema.
 				let lo = (L._flatidx & {v: FV}).out
 				let hi = (L._flatidx & {v: TV}).out
-				let schrange = list.Slice(L._sortedSchemas, lo+1, hi+1)
+				let schrange = list.Slice(L.schemas, lo+1, hi+1)
 
 				_accum: [{result: I, to: FV}, for i, schdef in schrange {
 					// alias pointing to the previous item in the list we're building

--- a/traverse.cue
+++ b/traverse.cue
@@ -27,7 +27,7 @@ package thema
 	inst: {...} // TODO consistently rename to 'object' or something
 
 	out: #SyntacticVersion
-	out: [ for _, sch in lin._sortedSchemas if ((sch._#schema & inst) != _|_) {sch.version}][0]
+	out: [ for _, sch in lin.schemas if ((sch._#schema & inst) != _|_) {sch.version}][0]
 }
 
 // #LinkedInstance represents data that is an instance of some schema, the


### PR DESCRIPTION
In #82, i added some native CUE logic to ensure that lenses and schemas were in a particular, expected sort order, regardless of the order the user provides them. This was conventional thinking about optimization - Translate operations needed to perform a lot of walking across these structures, and knowing that schemas and lenses were pre-sorted prior to the operation allowed retrieval of these objects by indexing, rather than more expensive search.

Unfortunately, the native CUE sorting - which relies on injected syntactic version comparators - is highly inefficient. And it's being performed pretty much everywhere that `#Lineage` is referenced and unified. Removing that sort logic resulted in almost absurd performance improvements...which is a good thing, because performance was categorically unacceptable before this change. Here's the [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) summary:

```
goos: darwin
goarch: amd64
pkg: github.com/grafana/thema
cpu: Intel(R) Core(TM) i5-1038NG7 CPU @ 2.00GHz
                                                                    │    old.txt    │               new.txt               │
                                                                    │    sec/op     │   sec/op     vs base                │
BasicTranslate/lineage/basic-multiversion/forward/simple-8            596.06m ± 87%   20.01m ± 7%  -96.64% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withoutOptional-8   566.09m ± 22%   26.76m ± 4%  -95.27% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withOptional-8      606.77m ± 81%   26.44m ± 4%  -95.64% (p=0.000 n=10)
UnifyLineage-8                                                        10.899m ±  9%   2.344m ± 4%  -78.50% (p=0.000 n=10)
BindLineage/PreUnified-8                                              17.367m ±  7%   4.262m ± 4%  -75.46% (p=0.000 n=10)
BindLineage/NotUnified-8                                              6784.9µ ± 10%   992.8µ ± 5%  -85.37% (p=0.000 n=10)
geomean                                                                80.04m         7.209m       -90.99%

                                                                    │    old.txt     │               new.txt                │
                                                                    │      B/op      │     B/op      vs base                │
BasicTranslate/lineage/basic-multiversion/forward/simple-8            72.680Mi ± 84%   3.399Mi ± 5%  -95.32% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withoutOptional-8   69.136Mi ± 22%   3.944Mi ± 3%  -94.30% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withOptional-8      74.231Mi ± 82%   3.928Mi ± 4%  -94.71% (p=0.000 n=10)
UnifyLineage-8                                                        1392.1Ki ±  0%   431.6Ki ± 0%  -69.00% (p=0.000 n=10)
BindLineage/PreUnified-8                                              2283.7Ki ±  0%   701.7Ki ± 0%  -69.27% (p=0.000 n=10)
BindLineage/NotUnified-8                                               808.7Ki ±  0%   187.0Ki ± 0%  -76.88% (p=0.000 n=10)
geomean                                                                9.813Mi         1.186Mi       -87.92%

                                                                    │    old.txt     │               new.txt               │
                                                                    │   allocs/op    │  allocs/op   vs base                │
BasicTranslate/lineage/basic-multiversion/forward/simple-8            1648.94k ± 84%   72.52k ± 5%  -95.60% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withoutOptional-8   1567.07k ± 22%   83.76k ± 4%  -94.66% (p=0.000 n=10)
BasicTranslate/lineage/basic-multiversion/reverse/withOptional-8      1682.77k ± 82%   83.43k ± 4%  -95.04% (p=0.000 n=10)
UnifyLineage-8                                                         31.883k ±  0%   8.623k ± 0%  -72.95% (p=0.000 n=10)
BindLineage/PreUnified-8                                                57.47k ±  0%   15.91k ± 0%  -72.31% (p=0.000 n=10)
BindLineage/NotUnified-8                                               18.061k ±  0%   3.687k ± 0%  -79.59% (p=0.000 n=10)
geomean                                                                 228.9k         25.20k       -88.99%
```

The _smallest_ impact on our test suite was cutting execution time by more than two-thirds. For our worst operation, translate, execution time was reduced by more than 95%.


The tradeoff, of course, is that it is no longer acceptable for the user to write their `schemas` and `lenses` arrays in any order. I'm not sure that's much of a tradeoff though, TBH - i see little value in allowing flexibility in the order of declaration, anyway.

As-written, this PR is a UX regression in using Thema from pure CUE, as at least lenses will allow incorrect input orderings and only exhibit bizarre problems (arising from unmet lens index expectations) when running translate operations.

When using Thema from Go, this needn't be an issue, as we can enforce that the declared input ordering is correct in `BindLineage()`. We may be able to add some native CUE checks that enforce this, too, without hurting performance (no sorting, just asserting!). This PR doesn't add those checks, as i think we should defer that to a follow-up in order to stop the bleeding here as quickly as possible.

Fixes #137 