### PR TITLE
Chore: Generate `any` instead of `interface{}` in Go code

### DIFF
--- a/encoding/gocode/decorators.go
+++ b/encoding/gocode/decorators.go
@@ -228,7 +228,7 @@ func withoutUnderscore(i *dst.Ident) {
 func withoutRawData(existingFields map[string]bool) func(ident *dst.Ident) {
 	return func(i *dst.Ident) {
 		if existingFields[i.Name] {
-			i.Name = setStar(i) + "interface{}"
+			i.Name = setStar(i) + "any"
 		}
 	}
 }

--- a/internal/deepmap/oapi-codegen/pkg/codegen/codegen_test.go
+++ b/internal/deepmap/oapi-codegen/pkg/codegen/codegen_test.go
@@ -69,8 +69,8 @@ type GetTestByNameResponse struct {
 	HTTPResponse *http.Response
 	JSON200      *[]Test
 	XML200       *[]Test
-	JSON422      *[]interface{}
-	XML422       *[]interface{}
+	JSON422      *[]any
+	XML422       *[]any
 	JSONDefault  *Error
 }`)
 

--- a/internal/deepmap/oapi-codegen/pkg/codegen/schema.go
+++ b/internal/deepmap/oapi-codegen/pkg/codegen/schema.go
@@ -225,7 +225,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 	// i.e. the parent schema defines a type:array, but the array has
 	// no items defined. Therefore, we have at least valid Go-Code.
 	if sref == nil {
-		return Schema{GoType: "interface{}"}, nil
+		return Schema{GoType: "any"}, nil
 	}
 
 	schema := sref.Value
@@ -306,11 +306,11 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			if t == "object" {
 				// We have an object with no properties. This is a generic object
 				// expressed as a map.
-				outType = "map[string]interface{}"
+				outType = "map[string]any"
 			} else { // t == ""
 				// If we don't even have the object designator, we're a completely
 				// generic type.
-				outType = "interface{}"
+				outType = "any"
 			}
 			outSchema.GoType = outType
 			outSchema.DefineViaAlias = true
@@ -326,7 +326,7 @@ func GenerateGoSchema(sref *openapi3.SchemaRef, path []string) (Schema, error) {
 			// Until we have a concrete additional properties type, we default to
 			// any schema.
 			outSchema.AdditionalPropertiesType = &Schema{
-				GoType: "interface{}",
+				GoType: "any",
 			}
 
 			// If additional properties are defined, we will override the default

--- a/internal/deepmap/oapi-codegen/pkg/codegen/template_helpers.go
+++ b/internal/deepmap/oapi-codegen/pkg/codegen/template_helpers.go
@@ -145,8 +145,8 @@ func genResponseUnmarshal(op *OperationDefinition) string {
 		sortedContentKeys := SortedContentKeys(responseRef.Value.Content)
 		for _, contentTypeName := range sortedContentKeys {
 
-			// We get "interface{}" when using "anyOf" or "oneOf" (which doesn't work with Go types):
-			if typeDefinition.TypeName == "interface{}" {
+			// We get "any" when using "anyOf" or "oneOf" (which doesn't work with Go types):
+			if typeDefinition.TypeName == "any" {
 				// Unable to unmarshal this, so we leave it out:
 				continue
 			}

--- a/testdata/lineage/any.txtar
+++ b/testdata/lineage/any.txtar
@@ -1,0 +1,269 @@
+# lineage containing fields that must generate any type in Go
+-- in.cue --
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "any"
+schemas: [{
+    version: [0, 0]
+    schema: {
+        value: string | bool
+        optional?: string | bool
+        emptyMap: {...}
+
+        structVal: {
+            inner: string | int
+            innerOptional?: _
+        }
+    }
+}]
+lenses: []
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== any_type_0.0_gen.go
+package any
+
+// Any defines model for any.
+type Any struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/encoding/gocode/TestGenerate/group --
+== any_type_0.0_gen.go
+package any
+
+// EmptyMap defines model for emptyMap.
+type EmptyMap = map[string]any
+
+// StructVal defines model for structVal.
+type StructVal struct {
+	Inner         any  `json:"inner"`
+	InnerOptional *any `json:"innerOptional,omitempty"`
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== any_type_0.0_gen.go
+package any
+
+// Any defines model for any.
+type Any struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  any            `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any `json:"inner"`
+		InnerOptional any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== any_type_0.0_gen.go
+package any
+
+// Any defines model for any.
+type Any struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/encoding/gocode/TestGenerate/expandref --
+== any_type_0.0_gen.go
+package any
+
+// Any defines model for any.
+type Any struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/bind --
+Schema count: 1
+Schema versions: 0.0
+Lenses count: 0
+-- out/encoding/openapi/TestGenerate/nilcfg --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "any",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "any": {
+        "type": "object",
+        "required": [
+          "value",
+          "emptyMap",
+          "structVal"
+        ],
+        "properties": {
+          "value": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "optional": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "emptyMap": {
+            "type": "object"
+          },
+          "structVal": {
+            "type": "object",
+            "required": [
+              "inner"
+            ],
+            "properties": {
+              "inner": {
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  }
+                ]
+              },
+              "innerOptional": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/group --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "any",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "value": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "optional": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      },
+      "emptyMap": {
+        "type": "object"
+      },
+      "structVal": {
+        "type": "object",
+        "required": [
+          "inner"
+        ],
+        "properties": {
+          "inner": {
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              }
+            ]
+          },
+          "innerOptional": {}
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/expandrefs --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "any",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "any": {
+        "type": "object",
+        "required": [
+          "value",
+          "emptyMap",
+          "structVal"
+        ],
+        "properties": {
+          "value": {
+            "oneOf": [
+              {},
+              {}
+            ]
+          },
+          "optional": {
+            "oneOf": [
+              {},
+              {}
+            ]
+          },
+          "emptyMap": {
+            "type": "object",
+            "additionalProperties": {}
+          },
+          "structVal": {
+            "type": "object",
+            "required": [
+              "inner"
+            ],
+            "properties": {
+              "inner": {
+                "oneOf": [
+                  {},
+                  {}
+                ]
+              },
+              "innerOptional": {}
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/lineage/go-any.txtar
+++ b/testdata/lineage/go-any.txtar
@@ -3,7 +3,7 @@
 import "github.com/grafana/thema"
 
 thema.#Lineage
-name: "any"
+name: "go-any"
 schemas: [{
     version: [0, 0]
     schema: {
@@ -18,90 +18,18 @@ schemas: [{
     }
 }]
 lenses: []
--- out/encoding/gocode/TestGenerate/nilcfg --
-== any_type_0.0_gen.go
-package any
-
-// Any defines model for any.
-type Any struct {
-	EmptyMap  map[string]any `json:"emptyMap"`
-	Optional  *any           `json:"optional,omitempty"`
-	StructVal struct {
-		Inner         any  `json:"inner"`
-		InnerOptional *any `json:"innerOptional,omitempty"`
-	} `json:"structVal"`
-	Value any `json:"value"`
-}
--- out/encoding/gocode/TestGenerate/group --
-== any_type_0.0_gen.go
-package any
-
-// EmptyMap defines model for emptyMap.
-type EmptyMap = map[string]any
-
-// StructVal defines model for structVal.
-type StructVal struct {
-	Inner         any  `json:"inner"`
-	InnerOptional *any `json:"innerOptional,omitempty"`
-}
--- out/encoding/gocode/TestGenerate/depointerized --
-== any_type_0.0_gen.go
-package any
-
-// Any defines model for any.
-type Any struct {
-	EmptyMap  map[string]any `json:"emptyMap"`
-	Optional  any            `json:"optional,omitempty"`
-	StructVal struct {
-		Inner         any `json:"inner"`
-		InnerOptional any `json:"innerOptional,omitempty"`
-	} `json:"structVal"`
-	Value any `json:"value"`
-}
--- out/encoding/gocode/TestGenerate/godeclincomments --
-== any_type_0.0_gen.go
-package any
-
-// Any defines model for any.
-type Any struct {
-	EmptyMap  map[string]any `json:"emptyMap"`
-	Optional  *any           `json:"optional,omitempty"`
-	StructVal struct {
-		Inner         any  `json:"inner"`
-		InnerOptional *any `json:"innerOptional,omitempty"`
-	} `json:"structVal"`
-	Value any `json:"value"`
-}
--- out/encoding/gocode/TestGenerate/expandref --
-== any_type_0.0_gen.go
-package any
-
-// Any defines model for any.
-type Any struct {
-	EmptyMap  map[string]any `json:"emptyMap"`
-	Optional  *any           `json:"optional,omitempty"`
-	StructVal struct {
-		Inner         any  `json:"inner"`
-		InnerOptional *any `json:"innerOptional,omitempty"`
-	} `json:"structVal"`
-	Value any `json:"value"`
-}
--- out/bind --
-Schema count: 1
-Schema versions: 0.0
-Lenses count: 0
 -- out/encoding/openapi/TestGenerate/nilcfg --
 == 0.0.json
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "any",
+    "title": "goany",
     "version": "0.0"
   },
   "paths": {},
   "components": {
     "schemas": {
-      "any": {
+      "goany": {
         "type": "object",
         "required": [
           "value",
@@ -156,12 +84,26 @@ Lenses count: 0
     }
   }
 }
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== goany_type_0.0_gen.go
+package goany
+
+// Goany defines model for goany.
+type Goany struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
 -- out/encoding/openapi/TestGenerate/group --
 == 0.0.json
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "any",
+    "title": "goany",
     "version": "0.0"
   },
   "paths": {},
@@ -212,18 +154,34 @@ Lenses count: 0
     }
   }
 }
+-- out/encoding/gocode/TestGenerate/group --
+== goany_type_0.0_gen.go
+package goany
+
+// EmptyMap defines model for emptyMap.
+type EmptyMap = map[string]any
+
+// StructVal defines model for structVal.
+type StructVal struct {
+	Inner         any  `json:"inner"`
+	InnerOptional *any `json:"innerOptional,omitempty"`
+}
+-- out/bind --
+Schema count: 1
+Schema versions: 0.0
+Lenses count: 0
 -- out/encoding/openapi/TestGenerate/expandrefs --
 == 0.0.json
 {
   "openapi": "3.0.0",
   "info": {
-    "title": "any",
+    "title": "goany",
     "version": "0.0"
   },
   "paths": {},
   "components": {
     "schemas": {
-      "any": {
+      "goany": {
         "type": "object",
         "required": [
           "value",
@@ -266,4 +224,46 @@ Lenses count: 0
       }
     }
   }
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== goany_type_0.0_gen.go
+package goany
+
+// Goany defines model for goany.
+type Goany struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  any            `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any `json:"inner"`
+		InnerOptional any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== goany_type_0.0_gen.go
+package goany
+
+// Goany defines model for goany.
+type Goany struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
+}
+-- out/encoding/gocode/TestGenerate/expandref --
+== goany_type_0.0_gen.go
+package goany
+
+// Goany defines model for goany.
+type Goany struct {
+	EmptyMap  map[string]any `json:"emptyMap"`
+	Optional  *any           `json:"optional,omitempty"`
+	StructVal struct {
+		Inner         any  `json:"inner"`
+		InnerOptional *any `json:"innerOptional,omitempty"`
+	} `json:"structVal"`
+	Value any `json:"value"`
 }


### PR DESCRIPTION
Does what it says in the title.

Fixes: https://github.com/grafana/thema/issues/138