### PR TITLE
thema: Tidy up base package and docs

### DIFF
--- a/assignable.go
+++ b/assignable.go
@@ -15,7 +15,7 @@ import (
 // If the provided T is a pointer, it will be dereferenced before verification.
 // Double pointers (or any n-pointer > 1) are not allowed.
 //
-// The provided T must struct-kinded, as it is a requirement that all Thema
+// The provided T must be struct-kinded, as it is a requirement that all Thema
 // schemas are of base type struct.
 //
 //	type MyType struct {

--- a/assignable.go
+++ b/assignable.go
@@ -15,8 +15,8 @@ import (
 // If the provided T is a pointer, it will be dereferenced before verification.
 // Double pointers (or any n-pointer > 1) are not allowed.
 //
-// The provided T must necessarily be of struct type, as it is a requirement
-// that all Thema schemas are of base type struct.
+// The provided T must struct-kinded, as it is a requirement that all Thema
+// schemas are of base type struct.
 //
 //	type MyType struct {
 //		MyField string `json:"myfield"`
@@ -32,9 +32,11 @@ func AssignableTo(sch Schema, T any) error {
 	return assignable(sch.Underlying().LookupPath(pathSchDef), T)
 }
 
-// ErrPointerDepth indicates that a Go type having pointer indirection depth > 1
-// (e.g. **struct{ V: string }) was provided to a Thema func that checks
-// assignability, such as [BindType].
+// ErrPointerDepth indicates that a Go type having pointer indirection depth greater than 1, such as
+//
+//	**struct{ V: string })
+//
+// was provided to a Thema func that checks assignability, such as [BindType].
 var ErrPointerDepth = errors.New("assignability does not support more than one level of pointer indirection")
 
 const scalarKinds = cue.NullKind | cue.BoolKind |

--- a/encoding/cue/encode.go
+++ b/encoding/cue/encode.go
@@ -124,7 +124,7 @@ func appendlin(lin thema.Lineage, sch cue.Value) (ast.Node, error) {
 	linf := astutil.Format(lin.Underlying()).(*ast.File)
 	schnode := astutil.ToExpr(astutil.Format(sch))
 
-	lv := thema.LatestVersion(lin)
+	lv := lin.Latest().Version()
 	lsch := thema.SchemaP(lin, lv)
 	if err := compat.ThemaCompatible(lsch.Underlying(), sch); err == nil {
 		// Is compatible, bump minor version

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,6 +1,8 @@
 package errors
 
-import "github.com/cockroachdb/errors"
+import (
+	"github.com/cockroachdb/errors"
+)
 
 // ValidationCode represents different classes of validation errors that may
 // occur vs. concrete data inputs.

--- a/impl.go
+++ b/impl.go
@@ -7,27 +7,6 @@ import (
 	"cuelang.org/go/cue/errors"
 )
 
-// ErrValueNotExist indicates that an operation failed because a provided
-// cue.Value does not exist.
-type ErrValueNotExist struct {
-	path string
-}
-
-func (e *ErrValueNotExist) Error() string {
-	return fmt.Sprintf("value from path %q does not exist, absent values cannot be lineages", e.path)
-}
-
-// ErrNoSchemaWithVersion indicates that an operation was requested against a
-// schema version that does not exist within a particular lineage.
-type ErrNoSchemaWithVersion struct {
-	lin Lineage
-	v   SyntacticVersion
-}
-
-func (e *ErrNoSchemaWithVersion) Error() string {
-	return fmt.Sprintf("lineage %q does not contain a schema with version %v", e.lin.Name(), e.v)
-}
-
 type compatInvariantError struct {
 	rawlin    cue.Value
 	violation [2]SyntacticVersion

--- a/lineage.go
+++ b/lineage.go
@@ -6,6 +6,8 @@ import (
 
 	"cuelang.org/go/cue"
 	cerrors "cuelang.org/go/cue/errors"
+	"github.com/cockroachdb/errors"
+	terrors "github.com/grafana/thema/errors"
 	"github.com/grafana/thema/internal/cuetil"
 )
 
@@ -40,7 +42,7 @@ type baseLineage struct {
 
 // BindLineage takes a raw [cue.Value], checks that it correctly follows Thema's
 // invariants, such as translatability and backwards compatibility version
-// numbering. If checks succeed, a [Lineage] is returned.
+// numbering. If these checks succeed, a [Lineage] is returned.
 //
 // This function is the only way to create non-nil Lineage objects. As a result,
 // all non-nil instances of Lineage in any Go program are guaranteed to follow
@@ -247,10 +249,7 @@ func (lin *baseLineage) Schema(v SyntacticVersion) (Schema, error) {
 	isValidLineage(lin)
 
 	if !synvExists(lin.allv, v) {
-		return nil, &ErrNoSchemaWithVersion{
-			lin: lin,
-			v:   v,
-		}
+		return nil, errors.Mark(errors.Newf("no schema with version %s in lineage %s", v, lin.name), terrors.ErrVersionNotExist)
 	}
 
 	return lin.schema(v), nil

--- a/schema.go
+++ b/schema.go
@@ -48,9 +48,10 @@ func (sch *schemaDef) Examples() map[string]*Instance {
 	for it.Next() {
 		label := it.Selector().String()
 		examples[label] = &Instance{
-			raw:  it.Value(),
-			name: label,
-			sch:  sch,
+			valid: true,
+			raw:   it.Value(),
+			name:  label,
+			sch:   sch,
 		}
 	}
 
@@ -86,9 +87,10 @@ func (sch *schemaDef) Validate(data cue.Value) (*Instance, error) {
 	}
 
 	return &Instance{
-		raw:  data,
-		sch:  sch,
-		name: "", // FIXME how are we getting this out?
+		valid: true,
+		raw:   data,
+		sch:   sch,
+		name:  "", // FIXME how are we getting this out?
 	}, nil
 }
 

--- a/surface.go
+++ b/surface.go
@@ -99,7 +99,7 @@ func SchemaP(lin Lineage, v SyntacticVersion) Schema {
 // LatestVersion returns the version number of the newest (largest) schema
 // version in the provided lineage.
 //
-// DEPRECATED: call Lineage.Latest().Version().
+// Deprecated: call Lineage.Latest().Version().
 func LatestVersion(lin Lineage) SyntacticVersion {
 	return lin.Latest().Version()
 }
@@ -109,7 +109,7 @@ func LatestVersion(lin Lineage) SyntacticVersion {
 //
 // An error indicates the number of the provided sequence does not exist.
 //
-// DEPRECATED: call Schema.LatestInMajor().Version() after loading a schema in the desired major version.
+// Deprecated: call Schema.LatestInMajor().Version() after loading a schema in the desired major version.
 func LatestVersionInSequence(lin Lineage, seqv uint) (SyntacticVersion, error) {
 	sch, err := lin.Schema(SV(seqv, 0))
 	if err != nil {
@@ -135,6 +135,8 @@ func LatestVersionInSequence(lin Lineage, seqv uint) (SyntacticVersion, error) {
 // the builder func to reduce stutter:
 //
 //	func Lineage ...
+//
+// Deprecated: having an explicit type for this adds little value.
 type LineageFactory func(*Runtime, ...BindOption) (Lineage, error)
 
 // A ConvergentLineageFactory is the same as a LineageFactory, but for a
@@ -143,6 +145,8 @@ type LineageFactory func(*Runtime, ...BindOption) (Lineage, error)
 // There is no reason to provide both a ConvergentLineageFactory and a
 // LineageFactory, as the latter is always reachable from the former. As such,
 // idiomatic naming conventions are unchanged.
+//
+// Deprecated: having an explicit type for this adds little value.
 type ConvergentLineageFactory[T Assignee] func(*Runtime, ...BindOption) (ConvergentLineage[T], error)
 
 // A BindOption defines options that may be specified only at initial


### PR DESCRIPTION
Assorted bits of housekeeping, related to thema readiness goals.

* Adds a bunch of missing godoc
* Gets rid of some unused code
* Adds internal checks on `thema.Instance` to ensure that it panics if not created by the system itself