### PR TITLE
feat: Return sane errors from Translate

### DIFF
--- a/cmd/thema/data.go
+++ b/cmd/thema/data.go
@@ -10,9 +10,10 @@ import (
 	"path/filepath"
 
 	"cuelang.org/go/cue"
+	"github.com/spf13/cobra"
+
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/vmux"
-	"github.com/spf13/cobra"
 )
 
 type dataCommand struct {
@@ -180,8 +181,11 @@ func (dc *dataCommand) runTranslate(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prior validations checked that the schema version exists in the lineage
-	tinst, lac := inst.Translate(dc.lla.dl.sch.Version())
-	if err := dc.validateTranslationResult(tinst, lac); err != nil {
+	tinst, lac, err := inst.Translate(dc.lla.dl.sch.Version())
+	if err != nil {
+		return err
+	}
+	if err = dc.validateTranslationResult(tinst, lac); err != nil {
 		return err
 	}
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -67,7 +67,7 @@ var (
 )
 
 // Translation errors. These all occur as a result of an invalid lens. Currently
-// these may be returned from [thema.Instance.TranslateErr]. Eventually, it is
+// these may be returned from [thema.Instance.Translate]. Eventually, it is
 // hoped that they will be caught statically in [thema.BindLineage] and cannot
 // occur at runtime.
 var (

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -66,6 +66,27 @@ var (
 	ErrInvalidOutOfBounds = errors.New("data is out of schema bounds")
 )
 
+// Translation errors. These all occur as a result of an invalid lens. Currently
+// these may be returned from [thema.Instance.TranslateErr]. Eventually, it is
+// hoped that they will be caught statically in [thema.BindLineage] and cannot
+// occur at runtime.
+var (
+	// ErrInvalidLens indicates that a lens is not correctly written. It is the parent
+	// to all other lens and translation errors, and is a child of ErrInvalidLineage.
+	ErrInvalidLens = errors.New("lens is invalid")
+
+	// ErrLensIncomplete indicates that translating some valid data through
+	// a lens produced a non-concrete result. This always indicates a problem with the
+	// lens as it is written, and as such is a child of ErrInvalidLens.
+	ErrLensIncomplete = errors.New("result of lens translation is not concrete")
+
+	// ErrLensResultIsInvalidData indicates that translating some valid data through a
+	// lens produced a result that was not an instance of the target schema. This
+	// always indicates a problem with the lens as it is written, and as such is a
+	// child of ErrInvalidLens.
+	ErrLensResultIsInvalidData = errors.New("result of lens translation is not valid for target schema")
+)
+
 // Lower level general errors
 var (
 	// ErrValueNotExist indicates that a necessary CUE value did not exist.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,17 +35,17 @@ type ValidationError struct {
 
 // Unwrap implements standard Go error unwrapping, relied on by errors.Is.
 //
-// All ValidationErrors wrap the general ErrNotAnInstance sentinel error.
+// All ValidationErrors wrap the general ErrInvalidData sentinel error.
 func (ve *ValidationError) Unwrap() error {
-	return ErrNotAnInstance
+	return ErrInvalidData
 }
 
 // Validation error codes/types
 var (
-	// ErrNotAnInstance is the general error that indicates some data failed validation
+	// ErrInvalidData is the general error that indicates some data failed validation
 	// against a Thema schema. Use it with errors.Is() to differentiate validation errors
 	// from other classes of failure.
-	ErrNotAnInstance = errors.New("data not a valid instance of schema")
+	ErrInvalidData = errors.New("data not a valid instance of schema")
 
 	// ErrInvalidExcessField indicates a validation failure in which the schema is
 	// treated as closed, and the data contains a field not specified in the schema.

--- a/instance.go
+++ b/instance.go
@@ -239,7 +239,3 @@ func (lac multiTranslationLacunas) AsList() []Lacuna {
 	}
 	return l
 }
-
-// func TranslateComposed(lin ComposedLineage) {
-
-// }

--- a/instance_test.go
+++ b/instance_test.go
@@ -35,7 +35,8 @@ func TestInstance_Translate(t *testing.T) {
 		for from := lin.First(); from != nil; from = from.Successor() {
 			for _, example := range from.Examples() {
 				for to := lin.First(); to != nil; to = to.Successor() {
-					tinst, lacunas := example.Translate(to.Version())
+					tinst, lacunas, err := example.Translate(to.Version())
+					require.NoError(t, err)
 					require.NotNil(t, tinst)
 
 					result := tinst.Underlying()
@@ -127,7 +128,8 @@ schemas: [
 	require.Equal(t, expected, got)
 
 	// Translate cue.Value (no lacunas)
-	tinst, _ := inst.Translate(SV(0, 1))
+	tinst, _, err := inst.Translate(SV(0, 1))
+	require.NoError(t, err)
 	require.Equal(t, SV(0, 0), inst.Schema().Version())
 
 	got, err = tinst.Underlying().LookupPath(cue.ParsePath("title")).String()

--- a/validate.go
+++ b/validate.go
@@ -49,7 +49,7 @@ func (e *onesidederr) Error() string {
 }
 
 func (e *onesidederr) Unwrap() error {
-	return terrors.ErrNotAnInstance
+	return terrors.ErrInvalidData
 }
 
 type twosidederr struct {
@@ -75,7 +75,7 @@ func (e *twosidederr) Error() string {
 }
 
 func (e *twosidederr) Unwrap() error {
-	return terrors.ErrNotAnInstance
+	return terrors.ErrInvalidData
 }
 
 // TODO differentiate this once we have generic composition to support trimming out irrelevant disj branches
@@ -86,13 +86,13 @@ type emptydisjunction struct {
 }
 
 func (e *emptydisjunction) Unwrap() error {
-	return terrors.ErrNotAnInstance
+	return terrors.ErrInvalidData
 }
 
 type validationFailure []error
 
 func (vf validationFailure) Unwrap() error {
-	return terrors.ErrNotAnInstance
+	return terrors.ErrInvalidData
 }
 
 func (vf validationFailure) Error() string {

--- a/vmux/typed.go
+++ b/vmux/typed.go
@@ -50,8 +50,9 @@ func NewTypedMux[T thema.Assignee](sch thema.TypedSchema[T], dec Decoder) TypedM
 			if inst, ierr := isch.Validate(v); ierr == nil {
 				trinst, lac, err := inst.Translate(sch.Version())
 				if err != nil {
-
+					return nil, nil, err
 				}
+
 				// TODO perf: introduce a typed translator to avoid wastefully re-binding the go type every time
 				tinst, err := thema.BindInstanceType(trinst, sch)
 				if err != nil {

--- a/vmux/typed.go
+++ b/vmux/typed.go
@@ -48,7 +48,11 @@ func NewTypedMux[T thema.Assignee](sch thema.TypedSchema[T], dec Decoder) TypedM
 			}
 
 			if inst, ierr := isch.Validate(v); ierr == nil {
-				trinst, lac := inst.Translate(sch.Version())
+				trinst, lac, err := inst.Translate(sch.Version())
+				if err != nil {
+
+				}
+				// TODO perf: introduce a typed translator to avoid wastefully re-binding the go type every time
 				tinst, err := thema.BindInstanceType(trinst, sch)
 				if err != nil {
 					panic(fmt.Errorf("unreachable, instance type should always be bindable: %w", err))

--- a/vmux/untyped.go
+++ b/vmux/untyped.go
@@ -48,8 +48,7 @@ func NewUntypedMux(sch thema.Schema, dec Decoder) UntypedMux {
 			}
 
 			if inst, ierr := isch.Validate(v); ierr == nil {
-				trinst, lac := inst.Translate(sch.Version())
-				return trinst, lac, nil
+				return inst.Translate(sch.Version())
 			}
 		}
 


### PR DESCRIPTION
This PR introduces better error handling for `Translate`.

The function signature is remaining the same for `Translate`, given the aspiration to eventually have it not return errors (as described in the new docs for it). It will still panic if errors occur.

But, we also introduce `TranslateErr`, which returns errors instead of panicking. All errors which could emerge from `TranslateErr` are instances (`errors.Is`) of the new `ErrInvalidLens` sentinel error value. (That won't actually work yet because we're still figuring out how to use cockroachdb/errors in the context of #164, but once we do this should "Just Work")

The error sentinel disambiguation will be especially helpful in the context of vmuxers, where a non-nil error could _either_ come from the validate step, or from the translate step.

Fixes #167 