### PR TITLE
gocode: Generate correct go types in unions will `null`

### DIFF
--- a/assignable_test.go
+++ b/assignable_test.go
@@ -352,6 +352,22 @@ func TestAssignable(t *testing.T) {
 			}
 			`, strconv.IntSize, strconv.IntSize),
 		},
+		"or-null": {
+			T: &struct {
+				Both   *string `json:"both,omitempty"`
+				NoOmit *string `json:"noOmit"`
+				// This case is the ugly ambiguous one - is the user saying that an empty string
+				// should be serialized as an absent field, but a nil pointer be serialized as
+				// null? WAAAAAAAT
+				Optional *string `json:"optional"`
+			}{},
+			cue: `typ: {
+				both: string | null
+				noOmit: string | null
+				optional?: string | null
+			}
+			`,
+		},
 	}
 
 	for name, tst := range tt {

--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -6,6 +6,7 @@ import (
 
 	"cuelang.org/go/cue/cuecontext"
 	copenapi "cuelang.org/go/encoding/openapi"
+
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/openapi"
 	"github.com/grafana/thema/internal/txtartest/bindlin"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 // contains openapi encoder fixes. commented out because impact for
 // most thema CLI uses is minimal, and others (e.g. grafana/grafana)
 // can hoist this themselves if they need it
-replace cuelang.org/go => github.com/sdboyer/cue v0.5.0-beta.2.0.20221218111347-341999f48bdb
+replace cuelang.org/go => github.com/sdboyer/cue v0.5.0-beta.2.0.20230712135403-bdc4772ae055
 
 require (
 	cuelang.org/go v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
-github.com/sdboyer/cue v0.5.0-beta.2.0.20221218111347-341999f48bdb h1:X6XJsprVDQnlG4vT5TVb+cRlGMU78L/IKej8Q6SDFGY=
-github.com/sdboyer/cue v0.5.0-beta.2.0.20221218111347-341999f48bdb/go.mod h1:okjJBHFQFer+a41sAe2SaGm1glWS8oEb6CmJvn5Zdws=
+github.com/sdboyer/cue v0.5.0-beta.2.0.20230712135403-bdc4772ae055 h1:ilCOPMIGucstzXKgCVzAT8g6tu+Ejyk0J1HhXZN2xm0=
+github.com/sdboyer/cue v0.5.0-beta.2.0.20230712135403-bdc4772ae055/go.mod h1:okjJBHFQFer+a41sAe2SaGm1glWS8oEb6CmJvn5Zdws=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
 github.com/sergi/go-diff v1.3.1/go.mod h1:aMJSSKb2lpPvRNec0+w3fl7LP9IOFzdc9Pa4NFbPK1I=

--- a/testdata/lineage/union-null.txtar
+++ b/testdata/lineage/union-null.txtar
@@ -1,0 +1,358 @@
+# schema contains a disjunction with nulls in a branch
+
+-- in.cue --
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "union-null"
+schemas: [{
+	version: [0, 0]
+	schema: {
+		kindString: {
+			simpleString: string
+			withNull:     string | null
+		}
+		kindFloat: {
+			simpleFloat64: float64
+			simpleFloat32: float32
+			withNull64:    float64 | null
+			withNull32:    float32 | null
+		}
+		kindInt: {
+			simpleInt:   int
+			simpleInt32: int32
+			simpleInt64: int64
+			withNull:    int | null
+			withNull64:  int64 | null
+			withNull32:  int32 | null
+		}
+	}
+}]
+lenses: []
+-- out/bind --
+Schema count: 1
+Schema versions: 0.0
+Lenses count: 0
+-- out/encoding/openapi/TestGenerate/nilcfg --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unionnull",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "unionnull": {
+        "type": "object",
+        "required": [
+          "kindString",
+          "kindFloat",
+          "kindInt"
+        ],
+        "properties": {
+          "kindString": {
+            "type": "object",
+            "required": [
+              "simpleString",
+              "withNull"
+            ],
+            "properties": {
+              "simpleString": {
+                "type": "string"
+              },
+              "withNull": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "kindFloat": {
+            "type": "object",
+            "required": [
+              "simpleFloat64",
+              "simpleFloat32",
+              "withNull64",
+              "withNull32"
+            ],
+            "properties": {
+              "simpleFloat64": {
+                "type": "number",
+                "format": "double"
+              },
+              "simpleFloat32": {
+                "type": "number",
+                "format": "float"
+              },
+              "withNull64": {
+                "type": "number",
+                "minimum": -1.797693134862315708145274237317043567981E+308,
+                "maximum": 1.797693134862315708145274237317043567981E+308,
+                "nullable": true
+              },
+              "withNull32": {
+                "type": "number",
+                "minimum": -340282346638528859811704183484516925440,
+                "maximum": 340282346638528859811704183484516925440,
+                "nullable": true
+              }
+            }
+          },
+          "kindInt": {
+            "type": "object",
+            "required": [
+              "simpleInt",
+              "simpleInt32",
+              "simpleInt64",
+              "withNull",
+              "withNull64",
+              "withNull32"
+            ],
+            "properties": {
+              "simpleInt": {
+                "type": "integer"
+              },
+              "simpleInt32": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "simpleInt64": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "withNull": {
+                "type": "integer",
+                "nullable": true
+              },
+              "withNull64": {
+                "type": "integer",
+                "minimum": -9223372036854775808,
+                "maximum": 9223372036854775807,
+                "nullable": true
+              },
+              "withNull32": {
+                "type": "integer",
+                "minimum": -2147483648,
+                "maximum": 2147483647,
+                "nullable": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/group --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unionnull",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "kindString": {
+        "type": "object",
+        "required": [
+          "simpleString",
+          "withNull"
+        ],
+        "properties": {
+          "simpleString": {
+            "type": "string"
+          },
+          "withNull": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "kindFloat": {
+        "type": "object",
+        "required": [
+          "simpleFloat64",
+          "simpleFloat32",
+          "withNull64",
+          "withNull32"
+        ],
+        "properties": {
+          "simpleFloat64": {
+            "type": "number",
+            "format": "double"
+          },
+          "simpleFloat32": {
+            "type": "number",
+            "format": "float"
+          },
+          "withNull64": {
+            "type": "number",
+            "minimum": -1.797693134862315708145274237317043567981E+308,
+            "maximum": 1.797693134862315708145274237317043567981E+308,
+            "nullable": true
+          },
+          "withNull32": {
+            "type": "number",
+            "minimum": -340282346638528859811704183484516925440,
+            "maximum": 340282346638528859811704183484516925440,
+            "nullable": true
+          }
+        }
+      },
+      "kindInt": {
+        "type": "object",
+        "required": [
+          "simpleInt",
+          "simpleInt32",
+          "simpleInt64",
+          "withNull",
+          "withNull64",
+          "withNull32"
+        ],
+        "properties": {
+          "simpleInt": {
+            "type": "integer"
+          },
+          "simpleInt32": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "simpleInt64": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "withNull": {
+            "type": "integer",
+            "nullable": true
+          },
+          "withNull64": {
+            "type": "integer",
+            "minimum": -9223372036854775808,
+            "maximum": 9223372036854775807,
+            "nullable": true
+          },
+          "withNull32": {
+            "type": "integer",
+            "minimum": -2147483648,
+            "maximum": 2147483647,
+            "nullable": true
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/expandrefs --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "unionnull",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "unionnull": {
+        "type": "object",
+        "required": [
+          "kindString",
+          "kindFloat",
+          "kindInt"
+        ],
+        "properties": {
+          "kindString": {
+            "type": "object",
+            "required": [
+              "simpleString",
+              "withNull"
+            ],
+            "properties": {
+              "simpleString": {
+                "type": "string"
+              },
+              "withNull": {
+                "type": "string",
+                "nullable": true
+              }
+            }
+          },
+          "kindFloat": {
+            "type": "object",
+            "required": [
+              "simpleFloat64",
+              "simpleFloat32",
+              "withNull64",
+              "withNull32"
+            ],
+            "properties": {
+              "simpleFloat64": {
+                "type": "number",
+                "format": "double"
+              },
+              "simpleFloat32": {
+                "type": "number",
+                "format": "float"
+              },
+              "withNull64": {
+                "type": "number",
+                "minimum": -1.797693134862315708145274237317043567981E+308,
+                "maximum": 1.797693134862315708145274237317043567981E+308,
+                "nullable": true
+              },
+              "withNull32": {
+                "type": "number",
+                "minimum": -340282346638528859811704183484516925440,
+                "maximum": 340282346638528859811704183484516925440,
+                "nullable": true
+              }
+            }
+          },
+          "kindInt": {
+            "type": "object",
+            "required": [
+              "simpleInt",
+              "simpleInt32",
+              "simpleInt64",
+              "withNull",
+              "withNull64",
+              "withNull32"
+            ],
+            "properties": {
+              "simpleInt": {
+                "type": "integer"
+              },
+              "simpleInt32": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "simpleInt64": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "withNull": {
+                "type": "integer",
+                "nullable": true
+              },
+              "withNull64": {
+                "type": "integer",
+                "minimum": -9223372036854775808,
+                "maximum": 9223372036854775807,
+                "nullable": true
+              },
+              "withNull32": {
+                "type": "integer",
+                "minimum": -2147483648,
+                "maximum": 2147483647,
+                "nullable": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/testdata/lineage/union-null.txtar
+++ b/testdata/lineage/union-null.txtar
@@ -356,3 +356,130 @@ Lenses count: 0
     }
   }
 }
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== unionnull_type_0.0_gen.go
+package unionnull
+
+// Unionnull defines model for unionnull.
+type Unionnull struct {
+	KindFloat struct {
+		SimpleFloat32 float32  `json:"simpleFloat32"`
+		SimpleFloat64 float64  `json:"simpleFloat64"`
+		WithNull32    *float32 `json:"withNull32"`
+		WithNull64    *float64 `json:"withNull64"`
+	} `json:"kindFloat"`
+	KindInt struct {
+		SimpleInt   int    `json:"simpleInt"`
+		SimpleInt32 int32  `json:"simpleInt32"`
+		SimpleInt64 int64  `json:"simpleInt64"`
+		WithNull    *int   `json:"withNull"`
+		WithNull32  *int32 `json:"withNull32"`
+		WithNull64  *int64 `json:"withNull64"`
+	} `json:"kindInt"`
+	KindString struct {
+		SimpleString string  `json:"simpleString"`
+		WithNull     *string `json:"withNull"`
+	} `json:"kindString"`
+}
+-- out/encoding/gocode/TestGenerate/group --
+== unionnull_type_0.0_gen.go
+package unionnull
+
+// KindFloat defines model for kindFloat.
+type KindFloat struct {
+	SimpleFloat32 float32  `json:"simpleFloat32"`
+	SimpleFloat64 float64  `json:"simpleFloat64"`
+	WithNull32    *float32 `json:"withNull32"`
+	WithNull64    *float64 `json:"withNull64"`
+}
+
+// KindInt defines model for kindInt.
+type KindInt struct {
+	SimpleInt   int    `json:"simpleInt"`
+	SimpleInt32 int32  `json:"simpleInt32"`
+	SimpleInt64 int64  `json:"simpleInt64"`
+	WithNull    *int   `json:"withNull"`
+	WithNull32  *int32 `json:"withNull32"`
+	WithNull64  *int64 `json:"withNull64"`
+}
+
+// KindString defines model for kindString.
+type KindString struct {
+	SimpleString string  `json:"simpleString"`
+	WithNull     *string `json:"withNull"`
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== unionnull_type_0.0_gen.go
+package unionnull
+
+// Unionnull defines model for unionnull.
+type Unionnull struct {
+	KindFloat struct {
+		SimpleFloat32 float32 `json:"simpleFloat32"`
+		SimpleFloat64 float64 `json:"simpleFloat64"`
+		WithNull32    float32 `json:"withNull32"`
+		WithNull64    float64 `json:"withNull64"`
+	} `json:"kindFloat"`
+	KindInt struct {
+		SimpleInt   int   `json:"simpleInt"`
+		SimpleInt32 int32 `json:"simpleInt32"`
+		SimpleInt64 int64 `json:"simpleInt64"`
+		WithNull    int   `json:"withNull"`
+		WithNull32  int32 `json:"withNull32"`
+		WithNull64  int64 `json:"withNull64"`
+	} `json:"kindInt"`
+	KindString struct {
+		SimpleString string `json:"simpleString"`
+		WithNull     string `json:"withNull"`
+	} `json:"kindString"`
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== unionnull_type_0.0_gen.go
+package unionnull
+
+// Unionnull defines model for unionnull.
+type Unionnull struct {
+	KindFloat struct {
+		SimpleFloat32 float32  `json:"simpleFloat32"`
+		SimpleFloat64 float64  `json:"simpleFloat64"`
+		WithNull32    *float32 `json:"withNull32"`
+		WithNull64    *float32 `json:"withNull64"`
+	} `json:"kindFloat"`
+	KindInt struct {
+		SimpleInt   int   `json:"simpleInt"`
+		SimpleInt32 int32 `json:"simpleInt32"`
+		SimpleInt64 int64 `json:"simpleInt64"`
+		WithNull    *int  `json:"withNull"`
+		WithNull32  *int  `json:"withNull32"`
+		WithNull64  *int  `json:"withNull64"`
+	} `json:"kindInt"`
+	KindString struct {
+		SimpleString string  `json:"simpleString"`
+		WithNull     *string `json:"withNull"`
+	} `json:"kindString"`
+}
+-- out/encoding/gocode/TestGenerate/expandref --
+== unionnull_type_0.0_gen.go
+package unionnull
+
+// Unionnull defines model for unionnull.
+type Unionnull struct {
+	KindFloat struct {
+		SimpleFloat32 float32  `json:"simpleFloat32"`
+		SimpleFloat64 float64  `json:"simpleFloat64"`
+		WithNull32    *float32 `json:"withNull32"`
+		WithNull64    *float32 `json:"withNull64"`
+	} `json:"kindFloat"`
+	KindInt struct {
+		SimpleInt   int   `json:"simpleInt"`
+		SimpleInt32 int32 `json:"simpleInt32"`
+		SimpleInt64 int64 `json:"simpleInt64"`
+		WithNull    *int  `json:"withNull"`
+		WithNull32  *int  `json:"withNull32"`
+		WithNull64  *int  `json:"withNull64"`
+	} `json:"kindInt"`
+	KindString struct {
+		SimpleString string  `json:"simpleString"`
+		WithNull     *string `json:"withNull"`
+	} `json:"kindString"`
+}

--- a/testdata/lineage/union-null.txtar
+++ b/testdata/lineage/union-null.txtar
@@ -87,14 +87,12 @@ Lenses count: 0
               },
               "withNull64": {
                 "type": "number",
-                "minimum": -1.797693134862315708145274237317043567981E+308,
-                "maximum": 1.797693134862315708145274237317043567981E+308,
+                "format": "double",
                 "nullable": true
               },
               "withNull32": {
                 "type": "number",
-                "minimum": -340282346638528859811704183484516925440,
-                "maximum": 340282346638528859811704183484516925440,
+                "format": "float",
                 "nullable": true
               }
             }
@@ -127,14 +125,12 @@ Lenses count: 0
               },
               "withNull64": {
                 "type": "integer",
-                "minimum": -9223372036854775808,
-                "maximum": 9223372036854775807,
+                "format": "int64",
                 "nullable": true
               },
               "withNull32": {
                 "type": "integer",
-                "minimum": -2147483648,
-                "maximum": 2147483647,
+                "format": "int32",
                 "nullable": true
               }
             }
@@ -190,14 +186,12 @@ Lenses count: 0
           },
           "withNull64": {
             "type": "number",
-            "minimum": -1.797693134862315708145274237317043567981E+308,
-            "maximum": 1.797693134862315708145274237317043567981E+308,
+            "format": "double",
             "nullable": true
           },
           "withNull32": {
             "type": "number",
-            "minimum": -340282346638528859811704183484516925440,
-            "maximum": 340282346638528859811704183484516925440,
+            "format": "float",
             "nullable": true
           }
         }
@@ -230,14 +224,12 @@ Lenses count: 0
           },
           "withNull64": {
             "type": "integer",
-            "minimum": -9223372036854775808,
-            "maximum": 9223372036854775807,
+            "format": "int64",
             "nullable": true
           },
           "withNull32": {
             "type": "integer",
-            "minimum": -2147483648,
-            "maximum": 2147483647,
+            "format": "int32",
             "nullable": true
           }
         }
@@ -299,14 +291,12 @@ Lenses count: 0
               },
               "withNull64": {
                 "type": "number",
-                "minimum": -1.797693134862315708145274237317043567981E+308,
-                "maximum": 1.797693134862315708145274237317043567981E+308,
+                "format": "double",
                 "nullable": true
               },
               "withNull32": {
                 "type": "number",
-                "minimum": -340282346638528859811704183484516925440,
-                "maximum": 340282346638528859811704183484516925440,
+                "format": "float",
                 "nullable": true
               }
             }
@@ -339,14 +329,12 @@ Lenses count: 0
               },
               "withNull64": {
                 "type": "integer",
-                "minimum": -9223372036854775808,
-                "maximum": 9223372036854775807,
+                "format": "int64",
                 "nullable": true
               },
               "withNull32": {
                 "type": "integer",
-                "minimum": -2147483648,
-                "maximum": 2147483647,
+                "format": "int32",
                 "nullable": true
               }
             }

--- a/testdata/lineage/union-null.txtar
+++ b/testdata/lineage/union-null.txtar
@@ -443,15 +443,15 @@ type Unionnull struct {
 		SimpleFloat32 float32  `json:"simpleFloat32"`
 		SimpleFloat64 float64  `json:"simpleFloat64"`
 		WithNull32    *float32 `json:"withNull32"`
-		WithNull64    *float32 `json:"withNull64"`
+		WithNull64    *float64 `json:"withNull64"`
 	} `json:"kindFloat"`
 	KindInt struct {
-		SimpleInt   int   `json:"simpleInt"`
-		SimpleInt32 int32 `json:"simpleInt32"`
-		SimpleInt64 int64 `json:"simpleInt64"`
-		WithNull    *int  `json:"withNull"`
-		WithNull32  *int  `json:"withNull32"`
-		WithNull64  *int  `json:"withNull64"`
+		SimpleInt   int    `json:"simpleInt"`
+		SimpleInt32 int32  `json:"simpleInt32"`
+		SimpleInt64 int64  `json:"simpleInt64"`
+		WithNull    *int   `json:"withNull"`
+		WithNull32  *int32 `json:"withNull32"`
+		WithNull64  *int64 `json:"withNull64"`
 	} `json:"kindInt"`
 	KindString struct {
 		SimpleString string  `json:"simpleString"`
@@ -468,15 +468,15 @@ type Unionnull struct {
 		SimpleFloat32 float32  `json:"simpleFloat32"`
 		SimpleFloat64 float64  `json:"simpleFloat64"`
 		WithNull32    *float32 `json:"withNull32"`
-		WithNull64    *float32 `json:"withNull64"`
+		WithNull64    *float64 `json:"withNull64"`
 	} `json:"kindFloat"`
 	KindInt struct {
-		SimpleInt   int   `json:"simpleInt"`
-		SimpleInt32 int32 `json:"simpleInt32"`
-		SimpleInt64 int64 `json:"simpleInt64"`
-		WithNull    *int  `json:"withNull"`
-		WithNull32  *int  `json:"withNull32"`
-		WithNull64  *int  `json:"withNull64"`
+		SimpleInt   int    `json:"simpleInt"`
+		SimpleInt32 int32  `json:"simpleInt32"`
+		SimpleInt64 int64  `json:"simpleInt64"`
+		WithNull    *int   `json:"withNull"`
+		WithNull32  *int32 `json:"withNull32"`
+		WithNull64  *int64 `json:"withNull64"`
 	} `json:"kindInt"`
 	KindString struct {
 		SimpleString string  `json:"simpleString"`


### PR DESCRIPTION
Currently, having a `| null` ends up creating undesirable behavior for certain generated Go types - in particular, we see an `int64 | null` come across as `*int` instead of `*int64`.  (Actually, it seems to be wider - a disjunction with the sized keyword types causes the loss of precision in generated Go types).

Looks like the best fix is in our fork of oapi-codegen. PR so far just introduces a test case showing the problem - no fix.