### PR TITLE
First pass on refining error messages

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -8,6 +8,7 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/errors"
 	"cuelang.org/go/cue/token"
+
 	terrors "github.com/grafana/thema/errors"
 )
 
@@ -168,9 +169,6 @@ func mungeValidateErr(err error, sch Schema) error {
 			errs = append(errs, err)
 			continue
 		}
-
-		// We missed a case, wrap CUE err in a plea for help
-		errs = append(errs, fmt.Errorf("no Thema handler for CUE error, please file an issue against github.com/grafana/thema\nto improve this error output!\n\n%w", ee))
 	}
 	return errs
 }
@@ -196,8 +194,8 @@ func splitTokens(poslist []token.Pos) (schpos, datapos []token.Pos) {
 
 func trimThemaPath(parts []string) []string {
 	for i, s := range parts {
-		if s == "seqs" {
-			return parts[i+4:]
+		if s == "schemas" {
+			return parts[i+3:]
 		}
 	}
 

--- a/validate.go
+++ b/validate.go
@@ -144,6 +144,23 @@ func mungeValidateErr(err error, sch Schema) error {
 
 			errs = append(errs, err)
 			continue
+		case 2:
+			dataval, dvok := vals[0].(string)
+			schval, svok := vals[1].(string)
+			if !svok || !dvok {
+				break
+			}
+
+			errs = append(errs, &twosidederr{
+				schpos:  schpos,
+				datapos: datapos,
+				coords:  x,
+				sv:      schval,
+				dv:      dataval,
+				code:    terrors.OutOfBounds,
+			})
+			continue
+
 		case 4:
 			schval, svok := vals[0].(string)
 			dataval, dvok := vals[1].(string)
@@ -151,6 +168,12 @@ func mungeValidateErr(err error, sch Schema) error {
 			datakind, dkok := vals[3].(cue.Kind)
 			if !svok || !dvok || !skok || !dkok {
 				break
+			}
+
+			if schkind == cue.IntKind || schkind == cue.FloatKind || schkind == cue.NumberKind {
+				if m, ok := schErrMsgFormatMap[schval]; ok {
+					schval = m
+				}
 			}
 
 			err := &twosidederr{
@@ -171,6 +194,13 @@ func mungeValidateErr(err error, sch Schema) error {
 		}
 	}
 	return errs
+}
+
+var schErrMsgFormatMap = map[string]string{
+	"int & >=-2147483648 & <=2147483647":                                                                   "int32",
+	"int & >=-9223372036854775808 & <=9223372036854775807":                                                 "int64",
+	">=-340282346638528859811704183484516925440 & <=340282346638528859811704183484516925440":               "float32",
+	">=-1.797693134862315708145274237317043567981E+308 & <=1.797693134862315708145274237317043567981E+308": "float64",
 }
 
 func splitTokens(poslist []token.Pos) (schpos, datapos []token.Pos) {

--- a/validate.go
+++ b/validate.go
@@ -170,7 +170,7 @@ func mungeValidateErr(err error, sch Schema) error {
 				break
 			}
 
-			if schkind == cue.IntKind || schkind == cue.FloatKind || schkind == cue.NumberKind {
+			if schkind&cue.NumberKind > 0 {
 				if m, ok := schErrMsgFormatMap[schval]; ok {
 					schval = m
 				}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,1 +1,7 @@
 package thema
+
+import "testing"
+
+func TestBasicValidate(t *testing.T) {
+	lin := testLin(linstr)
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,7 +1,1 @@
 package thema
-
-import "testing"
-
-func TestBasicValidate(t *testing.T) {
-	lin := testLin(linstr)
-}


### PR DESCRIPTION
This is a first pass on refining error messages, with the following improvements:
- Hide CUE path details from validation error output, just display the failing attribute name (fixes #150) 
- Remove the spammy message, which looked weird for a library error
- Simplify the error message for well known numeric formats (`int64` instead of `int & >=-9223372036854775808 & <=9223372036854775807"`)
- Add a new case within `mungeValidateErr` to handle uncovered error case with msg `invalid value %v (out of bound %s)`

Thank you all!