### PR TITLE
gocode: Fix subpath generation in bindings

### DIFF
--- a/cmd/thema/lineage_subgen.go
+++ b/cmd/thema/lineage_subgen.go
@@ -13,12 +13,13 @@ import (
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/pkg/encoding/yaml"
 	"github.com/dave/dst"
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/modfile"
+
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/gocode"
 	"github.com/grafana/thema/encoding/jsonschema"
 	"github.com/grafana/thema/encoding/openapi"
-	"github.com/spf13/cobra"
-	"golang.org/x/mod/modfile"
 )
 
 type genCommand struct {
@@ -309,6 +310,11 @@ func (gc *genCommand) runGoBindings(cmd *cobra.Command, args []string) error {
 		TargetSchemaVersion: gc.sch.Version(),
 		PackageName:         gc.pkgname,
 	}
+
+	if gc.lla.lincuepath != "" {
+		cfg.CuePath = cue.ParsePath(gc.lla.lincuepath)
+	}
+
 	// emitting on stdout just skips all the complicated conditional gen bits
 	if !gc.stdout {
 		if !gc.noembed {

--- a/encoding/gocode/binding.tmpl
+++ b/encoding/gocode/binding.tmpl
@@ -5,7 +5,8 @@ import (
 	"io/fs"
 	"path/filepath"
 
-    "cuelang.org/go/cue/build"
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/build"
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/load"
 )

--- a/encoding/gocode/gen.go
+++ b/encoding/gocode/gen.go
@@ -17,11 +17,12 @@ import (
 	"github.com/dave/dst/decorator"
 	"github.com/dave/dst/dstutil"
 	"github.com/getkin/kin-openapi/openapi3"
+	"golang.org/x/tools/imports"
+
 	"github.com/grafana/thema"
 	"github.com/grafana/thema/encoding/openapi"
 	"github.com/grafana/thema/internal/deepmap/oapi-codegen/pkg/codegen"
 	"github.com/grafana/thema/internal/util"
-	"golang.org/x/tools/imports"
 )
 
 // All the parsed templates in the tmpl subdirectory
@@ -306,7 +307,7 @@ func GenerateLineageBinding(lin thema.Lineage, cfg *BindingConfig) ([]byte, erro
 		CueModName:          cfg.CueModName,
 		LoadDir:             cfg.LoadDir,
 		EmbedPath:           cfg.EmbedPath,
-		CUEPath:             cfg.CuePath.String(),
+		CUEPath:             fmt.Sprintf("%q", cfg.CuePath.String()),
 		BaseFactoryFuncName: "Lineage",
 		FactoryFuncName:     "Lineage",
 		IsConvergent:        cfg.Assignee != nil,


### PR DESCRIPTION
This fixes `thema lineage gen gobindings` to properly handle `-p` arguments, and ensures the resulting generated bindings file contains a properly quoted path.

Same as #131.