### PR TITLE
Test `Schema.Validate()` against the corpus

### DIFF
--- a/encoding/cue/rewrite_test.go
+++ b/encoding/cue/rewrite_test.go
@@ -8,6 +8,7 @@ import (
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/build"
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/grafana/thema"
 	tastutil "github.com/grafana/thema/internal/astutil"
 	"github.com/grafana/thema/internal/txtartest/vanilla"
 )
@@ -15,8 +16,9 @@ import (
 func TestRewriteLegacyLineage(t *testing.T) {
 	ctx := cuecontext.New()
 	(&vanilla.TxTarTest{
-		Root: "./testdata/legacylineage",
-		Name: "rewrite-legacy-lineage",
+		Root:    "./testdata/legacylineage",
+		Name:    "rewrite-legacy-lineage",
+		ThemaFS: thema.CueJointFS,
 	}).Run(t, func(tc *vanilla.Test) {
 		inst := ctx.BuildInstance(tc.Instance())
 		val, _ := tc.Value("sub")
@@ -45,8 +47,9 @@ func TestRewriteFundamentals(t *testing.T) {
 
 	// case 1
 	(&vanilla.TxTarTest{
-		Root: "./testdata/basicrewrite",
-		Name: "oneroot",
+		Root:    "./testdata/basicrewrite",
+		Name:    "oneroot",
+		ThemaFS: thema.CueJointFS,
 	}).Run(t, func(tc *vanilla.Test) {
 		// An instance with two input files - len(bi.Files) == 2
 		bi := tc.Instance()

--- a/encoding/gocode/gocode_test.go
+++ b/encoding/gocode/gocode_test.go
@@ -16,8 +16,9 @@ import (
 
 func TestGenerate(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "../../testdata/lineage",
-		Name: "encoding/gocode/TestGenerate",
+		Root:    "../../testdata/lineage",
+		Name:    "encoding/gocode/TestGenerate",
+		ThemaFS: thema.CueJointFS,
 		ToDo: map[string]string{
 			"lineage/defaultchange": "default backcompat invariants not working properly yet",
 			"lineage/optional":      "Optional fields do not satisfy struct.MinFields(), causing #Lineage constraints to fail",

--- a/encoding/openapi/oapi_test.go
+++ b/encoding/openapi/oapi_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestGenerate(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "../../testdata/lineage",
-		Name: "encoding/openapi/TestGenerate",
+		Root:    "../../testdata/lineage",
+		Name:    "encoding/openapi/TestGenerate",
+		ThemaFS: thema.CueJointFS,
 		ToDo: map[string]string{
 			"lineage/defaultchange": "default backcompat invariants not working properly yet",
 			"lineage/optional":      "Optional fields do not satisfy struct.MinFields(), causing #Lineage constraints to fail",

--- a/instance_test.go
+++ b/instance_test.go
@@ -17,8 +17,9 @@ import (
 
 func TestInstance_Translate(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/lineage",
-		Name: "core/instance/translate",
+		Root:    "./testdata/lineage",
+		Name:    "core/instance/translate",
+		ThemaFS: CueJointFS,
 	}
 
 	ctx := cuecontext.New()
@@ -139,8 +140,9 @@ schemas: [
 
 func BenchmarkBasicTranslate(b *testing.B) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/lineage",
-		Name: "core/instance/translate",
+		Root:    "./testdata/lineage",
+		Name:    "core/instance/translate",
+		ThemaFS: CueJointFS,
 	}
 
 	ctx := cuecontext.New()

--- a/internal/txtartest/vanilla/vanilla_txtar.go
+++ b/internal/txtartest/vanilla/vanilla_txtar.go
@@ -36,6 +36,7 @@ import (
 	"cuelang.org/go/pkg/encoding/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/thema/internal/envvars"
+	"github.com/grafana/thema/internal/util"
 	"golang.org/x/tools/txtar"
 )
 
@@ -45,6 +46,8 @@ import (
 type TxTarTest struct {
 	// Run TxTarTest on this directory.
 	Root string
+
+	ThemaFS fs.FS
 
 	// Name is a unique name for this test. The golden file for this test is
 	// derived from the out/<name> file in the .txtar file.
@@ -95,6 +98,8 @@ type Test struct {
 	outFiles []file
 
 	Archive *txtar.Archive
+
+	ThemaFS fs.FS
 
 	// The absolute path of the current test directory.
 	Dir string
@@ -280,24 +285,31 @@ func formatVanillaNode(t *testing.T, n ast.Node) []byte {
 // RawInstances returns the instances represented by this .txtar file. The
 // returned instances are not checked for errors.
 func (t *Test) RawInstances(args ...string) []*build.Instance {
-	return LoadVanilla(t.Archive, t.Dir, args...)
+	return LoadVanilla(t.ThemaFS, t.Archive, args...)
 }
 
 // LoadVanilla loads the instances of a txtar file. By default, it only loads
-// files in the root directory. Relative files in the archive are given an
-// absolute location by prefixing it with dir.
-func LoadVanilla(a *txtar.Archive, dir string, args ...string) []*build.Instance {
+// files in the root directory.
+func LoadVanilla(themaFS fs.FS, a *txtar.Archive, args ...string) []*build.Instance {
+	vfsRootDir := "/"
+
 	auto := len(args) == 0
 	overlay := map[string]load.Source{}
 	for _, f := range a.Files {
 		if auto && !strings.Contains(f.Name, "/") {
 			args = append(args, f.Name)
 		}
-		overlay[filepath.Join(dir, f.Name)] = load.FromBytes(f.Data)
+		overlay[filepath.Join(vfsRootDir, f.Name)] = load.FromBytes(f.Data)
+	}
+
+	if err := util.ToOverlay(filepath.Join(vfsRootDir, "cue.mod/pkg/github.com/grafana/thema"), themaFS, overlay); err != nil {
+		// util.ToOverlay() explores a virtual filesystem and any error is extremely unlikely.
+		// Having a panic here is probably alright since this function is only used in tests.
+		panic(err)
 	}
 
 	cfg := &load.Config{
-		Dir:     dir,
+		Dir:     vfsRootDir,
 		Overlay: overlay,
 	}
 
@@ -316,9 +328,7 @@ func (x *TxTarTest) Run(t *testing.T, f func(tc *Test)) {
 		t.Fatal(err)
 	}
 
-	root := x.Root
-
-	err = filepath.WalkDir(root, func(fullpath string, entry fs.DirEntry, err error) error {
+	err = filepath.WalkDir(x.Root, func(fullpath string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -339,6 +349,7 @@ func (x *TxTarTest) Run(t *testing.T, f func(tc *Test)) {
 			tc := &Test{
 				T:       t,
 				Archive: a,
+				ThemaFS: x.ThemaFS,
 				Dir:     filepath.Dir(filepath.Join(dir, fullpath)),
 				prefix:  path.Join("out", x.Name),
 			}

--- a/internal/txtartest/vanilla/vanilla_txtar.go
+++ b/internal/txtartest/vanilla/vanilla_txtar.go
@@ -34,9 +34,9 @@ import (
 	"cuelang.org/go/cue/load"
 	"cuelang.org/go/pkg/encoding/json"
 	"cuelang.org/go/pkg/encoding/yaml"
-	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/thema/internal/envvars"
 	"github.com/grafana/thema/internal/util"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/tools/txtar"
 )
 
@@ -444,9 +444,7 @@ func (x *TxTarTest) Run(t *testing.T, f func(tc *Test)) {
 					continue
 				}
 
-				t.Errorf("result for %s differs:\n%s",
-					sub.name,
-					cmp.Diff(string(gold.Data), string(result)))
+				require.Equal(t, string(gold.Data), string(result), "result for %s differs", sub.name)
 			}
 
 			// Add remaining unrelated files, ignoring files that were already

--- a/lineage_test.go
+++ b/lineage_test.go
@@ -15,8 +15,9 @@ import (
 
 func TestBindLineage(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/lineage",
-		Name: "bind",
+		Root:    "./testdata/lineage",
+		Name:    "bind",
+		ThemaFS: CueJointFS,
 		ToDo: map[string]string{
 			"lineage/defaultchange": "Thema compat analyzer fails to classify changes to default values as breaking",
 			"lineage/optional":      "Optional fields do not satisfy struct.MinFields(), causing #Lineage constraints to fail",
@@ -59,8 +60,9 @@ func TestBindLineage(t *testing.T) {
 
 func TestInvalidLineages(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/invalidlineage",
-		Name: "bindfail",
+		Root:    "./testdata/invalidlineage",
+		Name:    "bindfail",
+		ThemaFS: CueJointFS,
 		ToDo: map[string]string{
 			"invalidlineage/joindef":                "no invariant checker written to disallow definitions from joinSchema",
 			"invalidlineage/onlydef":                "Lineage schema non-emptiness constraints are temporarily suspended while migrating grafana to flattened lineage structure",
@@ -89,8 +91,9 @@ func TestInvalidLineages(t *testing.T) {
 
 func TestIsAppendOnly(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/isappendonly/valid",
-		Name: "isappendonly",
+		Root:    "./testdata/isappendonly/valid",
+		Name:    "isappendonly",
+		ThemaFS: CueJointFS,
 		ToDo: map[string]string{
 			"isappendonly/valid/withconstraints": "Subsume doesn't support constraints using built-in validators",
 			"isappendonly/valid/disjunction":     "Subsume requires the Final() option to consider two complex disjunctions as equal but this creates false negatives",
@@ -125,8 +128,9 @@ func TestIsAppendOnly(t *testing.T) {
 
 func TestIsAppendOnlyFail(t *testing.T) {
 	test := vanilla.TxTarTest{
-		Root: "./testdata/isappendonly/invalid",
-		Name: "isappendonly-fail",
+		Root:    "./testdata/isappendonly/invalid",
+		Name:    "isappendonly-fail",
+		ThemaFS: CueJointFS,
 	}
 
 	ctx := cuecontext.New()

--- a/testdata/invalidlineage/defonly.txtar
+++ b/testdata/invalidlineage/defonly.txtar
@@ -5,4 +5,4 @@ import "github.com/grafana/thema"
 thema.#Lineage
 -- out/bindfail --
 invalid lineage, #Lineage.name must be concrete:
-    ../../lineage.cue:16:2
+    ../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:16:2

--- a/testdata/invalidlineage/empty.txtar
+++ b/testdata/invalidlineage/empty.txtar
@@ -1,4 +1,4 @@
 -- in.cue --
 -- out/bindfail --
 not a lineage, missing #Lineage.name:
-    ./in.cue:1:1
+    ../../../../../../../in.cue:1:1

--- a/testdata/isappendonly/invalid/boundaries.txtar
+++ b/testdata/isappendonly/invalid/boundaries.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field anInt not present in {anInt:*12 | >0 & <=24 & int}:
-    ../../../lineage.cue:223:10
-    ./in.cue:7:10
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:7:10
 missing field "anInt"

--- a/testdata/isappendonly/invalid/default.txtar
+++ b/testdata/isappendonly/invalid/default.txtar
@@ -22,6 +22,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aunion not present in {aunion:*"bar" | "foo" | "baz"}:
-    ../../../lineage.cue:223:10
-    ./in.cue:16:13
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:16:13
 missing field "aunion"

--- a/testdata/isappendonly/invalid/embedref.txtar
+++ b/testdata/isappendonly/invalid/embedref.txtar
@@ -32,8 +32,8 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #EmbedRef not present in {#EmbedRef:{refField1:string,refField2:1},refField1:string,refField2:1}:
-    ../../../lineage.cue:223:10
-    ./in.cue:21:13
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:21:13
 field refField2 not present in {refField1:string,refField2:1}:
-    ./in.cue:24:20
+    ../../../../../../../../in.cue:24:20
 missing field "#EmbedRef"

--- a/testdata/isappendonly/invalid/nested.txtar
+++ b/testdata/isappendonly/invalid/nested.txtar
@@ -27,8 +27,8 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aNewOptionalField not present in {aField:string}:
-    ./in.cue:8:13
+    ../../../../../../../../in.cue:8:13
 field anObject not present in {anObject:{aField:string}}:
-    ../../../lineage.cue:223:10
-    ./in.cue:7:10
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:7:10
 missing field "anObject"

--- a/testdata/isappendonly/invalid/noref.txtar
+++ b/testdata/isappendonly/invalid/noref.txtar
@@ -34,7 +34,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field #Baz not present in {someField:string,#Baz:{run:string,tell:bytes}}:
-    ../../../lineage.cue:223:10
-    ./in.cue:22:13
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:22:13
 missing field "#Baz"
 required field is optional in subsumed value: dat

--- a/testdata/isappendonly/invalid/optional.txtar
+++ b/testdata/isappendonly/invalid/optional.txtar
@@ -23,6 +23,6 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aNewOptionalField not present in {aField:string}:
-    ../../../lineage.cue:223:10
-    ./in.cue:7:10
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:7:10
 missing field "aNewOptionalField"

--- a/testdata/isappendonly/invalid/refstruct.txtar
+++ b/testdata/isappendonly/invalid/refstruct.txtar
@@ -33,7 +33,7 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aBaz not present in {aBaz:{run:string,dat:>=-2147483648 & <=2147483647 & int},#Baz:{run:string,dat:>=-2147483648 & <=2147483647 & int}}:
-    ../../../lineage.cue:223:10
-    ./in.cue:22:13
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:22:13
 missing field "aBaz"
 required field is optional in subsumed value: tell

--- a/testdata/isappendonly/invalid/stringconstraint.txtar
+++ b/testdata/isappendonly/invalid/stringconstraint.txtar
@@ -35,10 +35,10 @@ lin2: schemas: [{
 }]
 -- out/isappendonly-fail --
 field aString not present in {aString:strings.MinRunes(2),anObject:{aField:int}}:
-    ../../../lineage.cue:223:10
-    ./in.cue:25:10
+    ../../../../../../../../cue.mod/pkg/github.com/grafana/thema/lineage.cue:223:10
+    ../../../../../../../../in.cue:25:10
 missing field "aString"
 invalid value strings.MinRunes(2) (does not satisfy strings.MinRunes(1)): error in call to strings.MinRunes: non-concrete value string:
-    ./in.cue:13:21
-    ./in.cue:13:38
-    ./in.cue:26:21
+    ../../../../../../../../in.cue:13:21
+    ../../../../../../../../in.cue:13:38
+    ../../../../../../../../in.cue:26:21

--- a/testdata/lineage/maps.txtar
+++ b/testdata/lineage/maps.txtar
@@ -1,13 +1,12 @@
 # a schema containing various different combinations of map-ish structures
 
-#lineagePath: lin
 #subpath
 -- in.cue --
 import "github.com/grafana/thema"
 
-lin: thema.#Lineage
-lin: name: "maps"
-lin: schemas: [{
+thema.#Lineage
+name: "maps"
+schemas: [{
 	version: [0, 0]
 	schema: {
 		valPrimitive: [string]: bool
@@ -20,7 +19,7 @@ lin: schemas: [{
 		someField: aMap
 	}
 }]
-lin: lenses: []
+lenses: []
 
 aMap: [string]: bool
 aStruct: foo:   string

--- a/testdata/lineage/scalars.txtar
+++ b/testdata/lineage/scalars.txtar
@@ -1,0 +1,228 @@
+# lineage containing a single schema with only scalar fields
+-- in.cue --
+
+import "github.com/grafana/thema"
+
+thema.#Lineage
+name: "scalar-fields"
+
+schemas: [{
+    version: [0, 0]
+    schema: {
+        someInt32: int32
+        someInt64: int64
+        someFloat32: float32
+        someFloat64: float64
+    }
+}]
+-- in/validate/TestValidate/someInt32.data.json --
+{
+    "someInt32": "not an int"
+}
+-- out/validate/TestValidate/someInt32 --
+<scalar-fields@v0.0>.someInt32: validation failed, data is not an instance:
+	schema expected `int32`
+	but data contained `"not an int"`
+		test:2:18
+-- in/validate/someInt64.data.json --
+{
+    "someInt64": "not an int64"
+}
+-- out/validate/TestValidate/someInt64 --
+<scalar-fields@v0.0>.someInt64: validation failed, data is not an instance:
+	schema expected `int64`
+	but data contained `"not an int64"`
+		test:2:18
+-- in/validate/TestValidate/someFloat32.data.json --
+{
+    "someFloat32": "I am a string"
+}
+-- out/validate/TestValidate/someFloat32 --
+<scalar-fields@v0.0>.someFloat32: validation failed, data is not an instance:
+	schema expected `float32`
+	but data contained `"I am a string"`
+		test:2:20
+-- in/validate/TestValidate/someFloat64.data.json --
+{
+    "someFloat64": "I am a string"
+}
+-- out/validate/TestValidate/someFloat64 --
+<scalar-fields@v0.0>.someFloat64: validation failed, data is not an instance:
+	schema expected `float64`
+	but data contained `"I am a string"`
+		test:2:20
+-- out/encoding/gocode/TestGenerate/nilcfg --
+== scalarfields_type_0.0_gen.go
+package scalarfields
+
+// Scalarfields defines model for scalarfields.
+type Scalarfields struct {
+	SomeFloat32 float32 `json:"someFloat32"`
+	SomeFloat64 float64 `json:"someFloat64"`
+	SomeInt32   int32   `json:"someInt32"`
+	SomeInt64   int64   `json:"someInt64"`
+}
+-- out/encoding/openapi/TestGenerate/nilcfg --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "scalarfields",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "scalarfields": {
+        "type": "object",
+        "required": [
+          "someInt32",
+          "someInt64",
+          "someFloat32",
+          "someFloat64"
+        ],
+        "properties": {
+          "someInt32": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "someInt64": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "someFloat32": {
+            "type": "number",
+            "format": "float"
+          },
+          "someFloat64": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/group --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "scalarfields",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "someInt32": {
+        "type": "integer",
+        "format": "int32"
+      },
+      "someInt64": {
+        "type": "integer",
+        "format": "int64"
+      },
+      "someFloat32": {
+        "type": "number",
+        "format": "float"
+      },
+      "someFloat64": {
+        "type": "number",
+        "format": "double"
+      }
+    }
+  }
+}
+-- out/encoding/openapi/TestGenerate/expandrefs --
+== 0.0.json
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "scalarfields",
+    "version": "0.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "scalarfields": {
+        "type": "object",
+        "required": [
+          "someInt32",
+          "someInt64",
+          "someFloat32",
+          "someFloat64"
+        ],
+        "properties": {
+          "someInt32": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "someInt64": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "someFloat32": {
+            "type": "number",
+            "format": "float"
+          },
+          "someFloat64": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      }
+    }
+  }
+}
+-- out/encoding/gocode/TestGenerate/depointerized --
+== scalarfields_type_0.0_gen.go
+package scalarfields
+
+// Scalarfields defines model for scalarfields.
+type Scalarfields struct {
+	SomeFloat32 float32 `json:"someFloat32"`
+	SomeFloat64 float64 `json:"someFloat64"`
+	SomeInt32   int32   `json:"someInt32"`
+	SomeInt64   int64   `json:"someInt64"`
+}
+-- out/encoding/gocode/TestGenerate/godeclincomments --
+== scalarfields_type_0.0_gen.go
+package scalarfields
+
+// Scalarfields defines model for scalarfields.
+type Scalarfields struct {
+	SomeFloat32 float32 `json:"someFloat32"`
+	SomeFloat64 float64 `json:"someFloat64"`
+	SomeInt32   int32   `json:"someInt32"`
+	SomeInt64   int64   `json:"someInt64"`
+}
+-- out/encoding/gocode/TestGenerate/expandref --
+== scalarfields_type_0.0_gen.go
+package scalarfields
+
+// Scalarfields defines model for scalarfields.
+type Scalarfields struct {
+	SomeFloat32 float32 `json:"someFloat32"`
+	SomeFloat64 float64 `json:"someFloat64"`
+	SomeInt32   int32   `json:"someInt32"`
+	SomeInt64   int64   `json:"someInt64"`
+}
+-- out/bind --
+Schema count: 1
+Schema versions: 0.0
+Lenses count: 0
+-- out/encoding/gocode/TestGenerate/group --
+== scalarfields_type_0.0_gen.go
+package scalarfields
+
+// SomeFloat32 defines model for someFloat32.
+type SomeFloat32 = float32
+
+// SomeFloat64 defines model for someFloat64.
+type SomeFloat64 = float64
+
+// SomeInt32 defines model for someInt32.
+type SomeInt32 = int32
+
+// SomeInt64 defines model for someInt64.
+type SomeInt64 = int64

--- a/testdata/lineage/trivial-two-comments.txtar
+++ b/testdata/lineage/trivial-two-comments.txtar
@@ -1,12 +1,11 @@
 # lineage containing two trivial schemas
-#lineagePath: lin
 -- in.cue --
 
 import "github.com/grafana/thema"
 
-lin: thema.#Lineage
-lin: name: "trivial-two-comments"
-lin: schemas: [{
+thema.#Lineage
+name: "trivial-two-comments"
+schemas: [{
     version: [0, 0]
 
     // This should be schema/object-level docs
@@ -26,7 +25,7 @@ lin: schemas: [{
     }
 }]
 
-lin: lenses: [{
+lenses: [{
     from: [0, 1]
     to: [0, 0]
     input: _

--- a/testdata/lineage/trivial-two.txtar
+++ b/testdata/lineage/trivial-two.txtar
@@ -1,12 +1,11 @@
 # lineage containing two trivial schemas
-#lineagePath: lin
 -- in.cue --
 
 import "github.com/grafana/thema"
 
-lin: thema.#Lineage
-lin: name: "trivial-two"
-lin: schemas: [{
+thema.#Lineage
+name: "trivial-two"
+schemas: [{
     version: [0, 0]
     schema: {
         firstfield: string
@@ -20,7 +19,7 @@ lin: schemas: [{
     }
 }]
 
-lin: lenses: [{
+lenses: [{
     from: [0, 1]
     to: [0, 0]
     input: _
@@ -28,6 +27,26 @@ lin: lenses: [{
         firstfield: input.firstfield
     }
 }]
+-- in/validate/TestValidate/firstfieldAsInt32.data.json --
+{
+    "firstfield": 42
+}
+-- out/validate/TestValidate/firstfieldAsInt32 --
+<trivial-two@v0.1>.firstfield: validation failed, data is not an instance:
+	schema expected `string`
+		/in.cue:15:21
+	but data contained `42`
+		test:2:19
+-- out/validate/TestValidate/secondfieldAsString --
+<trivial-two@v0.1>.secondfield: validation failed, data is not an instance:
+	schema expected `"foo"`
+		test:2:20
+	but data contained `int & >=-2147483648 & <=2147483647`
+		/cue.mod/pkg/github.com/grafana/thema/lineage.cue:234:20
+-- in/validate/TestValidate/secondfieldAsString.data.json --
+{
+    "secondfield": "foo"
+}
 -- out/encoding/openapi/TestGenerate/nilcfg --
 == 0.0.json
 {

--- a/validate.go
+++ b/validate.go
@@ -106,6 +106,7 @@ func (vf validationFailure) Error() string {
 	return buf.String()
 }
 
+// HERE BE DRAGONS, BRING A SWORD.
 func mungeValidateErr(err error, sch Schema) error {
 	_, is := err.(errors.Error)
 	if !is {

--- a/validate_test.go
+++ b/validate_test.go
@@ -48,7 +48,7 @@ func TestValidate(t *testing.T) {
 			_, err = lineage.Latest().Validate(data)
 			req.Error(err, "The data shouldn't be valid for the schema")
 
-			outputFileName := filepath.Base(strings.TrimRight(file.Name, ".data.json"))
+			outputFileName := filepath.Base(strings.TrimSuffix(file.Name, ".data.json"))
 
 			_, err = tc.Writer(outputFileName).Write([]byte(err.Error()))
 			req.NoError(err)

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,1 +1,133 @@
-package thema
+package thema_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/grafana/thema"
+	"github.com/grafana/thema/vmux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var ctx = cuecontext.New()
+var rt = thema.NewRuntime(ctx)
+
+func TestBasicValidate(t *testing.T) {
+	linstrs := []struct {
+		name   string
+		linstr string
+	}{{
+		name: "int32",
+		linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: int32
+			header?: string
+		},
+	},
+]`,
+	}, {
+		name: "int64",
+		linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: int64
+			header?: string
+		},
+	},
+]`},
+		{
+			name: "float32",
+			linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: float32
+			header?: string
+		},
+	},
+]`,
+		}, {
+			name: "float64",
+			linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: float64
+			header?: string
+		},
+	},
+]`}, {
+			name: "custom range",
+			linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: int32 & > 10 & < 20
+			header?: string
+		},
+	},
+]`}, {
+			name: "disjunction",
+			linstr: `name: "simple"
+schemas: [
+	{
+		version: [0, 0]
+		schema:
+		{
+			title: float64 | null
+			header?: string
+		},
+	},
+]`,
+		}}
+
+	for _, tc := range linstrs {
+		t.Run(tc.name, func(t *testing.T) {
+			linval := rt.Context().CompileString(tc.linstr)
+			lin, err := thema.BindLineage(linval, rt)
+			require.NoError(t, err)
+
+			data, err := decodeData(`{"title": "null"}`)
+			if err != nil {
+				require.NoError(t, err)
+			}
+
+			latest := lin.Latest()
+
+			_, err = latest.Validate(data)
+			if err != nil {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func decodeData(inputJSON string) (cue.Value, error) {
+	if inputJSON == "" {
+		return cue.Value{}, errors.New("test error - data is missing")
+	}
+
+	jd := vmux.NewJSONCodec("test")
+	datval, err := jd.Decode(rt.Underlying().Context(), []byte(inputJSON))
+	if err != nil {
+		return cue.Value{}, fmt.Errorf("test error - failed to decode input data: %w", err)
+	}
+	return datval, nil
+}


### PR DESCRIPTION
This PR adds a test case that relies on the existing corpus of lineages and schemas to test the validation process.

The idea is to extend the current corpus with examples of inputs to validate against, see the errors that come out, evaluate their correctness/friendliness, and then implement the necessary fixes.

Here we focused mainly on being able to run this type of test. A following PR will augment the corpus with more test cases, that we can rely on to safely refactor our "error munging" function.