### PR TITLE
thema: Initial pass at Go lenses/migrations

### DIFF
--- a/bind.go
+++ b/bind.go
@@ -54,7 +54,7 @@ type lensID struct {
 	From, To SyntacticVersion
 }
 
-func lid(to, from SyntacticVersion) lensID {
+func lid(from, to SyntacticVersion) lensID {
 	return lensID{from, to}
 }
 
@@ -218,7 +218,7 @@ func (ml *maybeLineage) checkGoLensCompleteness() error {
 	// TODO(sdboyer) it'd be nice to consolidate all the errors so that the user always sees a complete set of problems
 	all := make(map[lensID]bool)
 	for _, lens := range ml.implens {
-		id := lid(lens.To, lens.From)
+		id := lid(lens.From, lens.To)
 		if all[id] {
 			return fmt.Errorf("duplicate Go migration %s", id)
 		}
@@ -234,7 +234,7 @@ func (ml *maybeLineage) checkGoLensCompleteness() error {
 	for _, sch := range ml.schlist[1:] {
 		// there must always at least be a reverse lens
 		v := sch.Version()
-		revid := lid(prior, v)
+		revid := lid(v, prior)
 
 		if !all[revid] {
 			missing = append(missing, revid)
@@ -244,7 +244,7 @@ func (ml *maybeLineage) checkGoLensCompleteness() error {
 
 		if v[0] != prior[0] {
 			// if we crossed a major version, there must also be a forward lens
-			fwdid := lid(v, prior)
+			fwdid := lid(prior, v)
 			if !all[fwdid] {
 				missing = append(missing, fwdid)
 			} else {
@@ -272,7 +272,7 @@ func (ml *maybeLineage) checkGoLensCompleteness() error {
 		// walk the slice so output is reliably ordered
 		for _, lens := range ml.implens {
 			// if it's not in the list it's because it was expected & already processed
-			elid := lid(lens.To, lens.From)
+			elid := lid(lens.From, lens.To)
 			if _, has := all[elid]; !has {
 				continue
 			}
@@ -301,7 +301,7 @@ func (ml *maybeLineage) checkGoLensCompleteness() error {
 
 	ml.lensmap = make(map[lensID]ImperativeLens, len(ml.implens))
 	for _, lens := range ml.implens {
-		ml.lensmap[lid(lens.To, lens.From)] = lens
+		ml.lensmap[lid(lens.From, lens.To)] = lens
 	}
 
 	return nil

--- a/bind.go
+++ b/bind.go
@@ -215,11 +215,15 @@ func (ml *maybeLineage) checkLensesOrder() error {
 }
 
 func (ml *maybeLineage) checkGoLensCompleteness() error {
+	// TODO(sdboyer) it'd be nice to consolidate all the errors so that the user always sees a complete set of problems
 	all := make(map[lensID]bool)
 	for _, lens := range ml.implens {
 		id := lid(lens.To, lens.From)
 		if all[id] {
 			return fmt.Errorf("duplicate Go migration %s", id)
+		}
+		if lens.Mapper == nil {
+			return fmt.Errorf("nil Go migration func for %s", id)
 		}
 		all[id] = true
 	}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -108,6 +108,20 @@ var (
 	// ErrInvalidLensesOrder indicates that lenses are in the wrong order - they must be sorted by `to`, then `from`.
 	ErrInvalidLensesOrder = errors.New("lenses in lineage are not ordered by version")
 
+	// ErrDuplicateLenses indicates that a lens was defined declaratively in CUE, but the same lens
+	// was also provided as a Go function to BindLineage.
+	ErrDuplicateLenses = errors.New("lens is declared in both CUE and Go")
+
+	// ErrMissingLenses indicates that the lenses provided to BindLineage in either
+	// CUE or Go were missing at least one of the expected lenses determined by the
+	// set of schemas in the lineage.
+	ErrMissingLenses = errors.New("not all expected lenses were provided")
+
+	// ErrErroneousLenses indicates that a lens was provided to BindLineage in either
+	// CUE or Go that was not one of the expected lenses determined by the set of
+	// schemas in the lineage.
+	ErrErroneousLenses = errors.New("unexpected lenses were erroneously provided")
+
 	// ErrVersionNotExist indicates that no schema exists in a lineage with a
 	// given version.
 	ErrVersionNotExist = errors.New("lineage does not contain schema with version") // ErrNoSchemaWithVersion

--- a/gomig_test.go
+++ b/gomig_test.go
@@ -1,0 +1,327 @@
+package thema
+
+import (
+	"testing"
+
+	"cuelang.org/go/cue/cuecontext"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoMigrations(t *testing.T) {
+	multivlin := `
+name: "basic-multiversion"
+
+schemas: [{
+    version: [0, 0]
+    schema: {
+        init: string
+    }
+    examples: {
+        simple: {
+            init: "some string"
+        }
+    }
+},
+{
+    version: [0, 1]
+    schema: {
+        init:      string
+        optional?: int32
+    }
+    examples: {
+        withoutOptional: {
+            init: "some string"
+        }
+        withOptional: {
+            init: "some string"
+            optional: 32
+        }
+    }
+},
+{
+    version: [0, 2]
+    schema: {
+        init:        string
+        optional?:   int32
+        withDefault?: *"foo" | "bar"
+    }
+    examples: {
+        withoutOptional: {
+            init: "some string"
+            withDefault: "foo"
+        }
+        withOptional: {
+            init: "some string"
+            optional: 32
+            withDefault: "bar"
+        }
+    }
+},
+{
+    version: [0, 3]
+    schema: {
+        init:        string
+        optional?:   int32
+        withDefault?: *"foo" | "bar" | "baz"
+    }
+    examples: {
+        withoutOptional: {
+            init: "some string"
+            withDefault: "baz"
+        }
+        withOptional: {
+            init: "some string"
+            optional: 32
+            withDefault: "baz"
+        }
+    }
+},
+{
+    version: [1, 0]
+    schema: {
+        renamed:     string
+        optional?:   int32
+        withDefault: "foo" | *"bar" | "baz"
+    }
+    examples: {
+        withoutOptional: {
+            renamed: "some string"
+            withDefault: "foo"
+        }
+        withOptional: {
+            renamed: "some string"
+            optional: 32
+            withDefault: "bar"
+        }
+    }
+},
+{
+    version: [1, 1]
+    schema: {
+        renamed:     string
+        optional?:   int32
+        withDefault: "foo" | *"bar" | "baz" | "bing"
+    }
+    examples: {
+        withoutOptional: {
+            renamed: "some string"
+            withDefault: "bing"
+        }
+        withOptional: {
+            renamed: "some string"
+            optional: 32
+            withDefault: "bing"
+        }
+    }
+},
+{
+    version: [2, 0]
+    schema: {
+        toObj:     {
+            init: string
+        }
+        optional?:   int32
+        withDefault: "foo" | *"bar" | "baz" | "bing"
+    }
+    examples: {
+        withoutOptional: {
+            toObj: {
+                init: "some string"
+            }
+            withDefault: "bing"
+        }
+        withOptional: {
+            toObj: {
+                init: "some string"
+            }
+            optional: 32
+            withDefault: "bing"
+        }
+    }
+}]
+`
+
+	lenses := []ImperativeLens{
+		{
+			To:   SV(0, 0),
+			From: SV(0, 1),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"init": m["init"],
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(0, 1),
+			From: SV(0, 2),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"init": m["init"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(0, 2),
+			From: SV(0, 3),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"init": m["init"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				// optional fields with defaults are weeeeird
+				if v, has := m["withDefault"]; has {
+					tom["withDefault"] = v
+				} else {
+					tom["withDefault"] = "foo"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(0, 3),
+			From: SV(1, 0),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"init": m["renamed"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				// optional fields with defaults are weeeeird
+				if v, has := m["withDefault"]; has {
+					if v == "bar" {
+						tom["withDefault"] = "foo"
+					} else {
+						tom["withDefault"] = v
+					}
+				} else {
+					tom["withDefault"] = "foo"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(1, 0),
+			From: SV(0, 3),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"renamed": m["init"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				if v, has := m["withDefault"]; has {
+					if v == "foo" {
+						tom["withDefault"] = "bar"
+					} else {
+						tom["withDefault"] = v
+					}
+				} else {
+					tom["withDefault"] = "bar"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(1, 0),
+			From: SV(1, 1),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"renamed": m["renamed"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				if v, has := m["withDefault"]; has {
+					tom["withDefault"] = v
+				} else {
+					tom["withDefault"] = "bar"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(1, 1),
+			From: SV(2, 0),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"renamed": m["toObj"].(map[string]any)["init"],
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				if v, has := m["withDefault"]; has {
+					tom["withDefault"] = v
+				} else {
+					tom["withDefault"] = "bar"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+		{
+			To:   SV(2, 0),
+			From: SV(1, 1),
+			Mapper: func(inst *Instance, to Schema) (*Instance, error) {
+				m := tomap(inst)
+
+				tom := map[string]any{
+					"toObj": map[string]any{
+						"init": m["renamed"],
+					},
+				}
+				if v, has := m["optional"]; has {
+					tom["optional"] = v
+				}
+				if v, has := m["withDefault"]; has {
+					tom["withDefault"] = v
+				} else {
+					tom["withDefault"] = "bar"
+				}
+
+				return to.Validate(to.Underlying().Context().Encode(tom))
+			},
+		},
+	}
+	ctx := cuecontext.New()
+	rt := NewRuntime(ctx)
+	linval := rt.Context().CompileString(multivlin)
+	_, err := BindLineage(linval, rt, ImperativeLenses(lenses...))
+	require.NoError(t, err)
+}
+
+func tomap(inst *Instance) map[string]any {
+	m := make(map[string]any)
+	err := inst.Underlying().Decode(&m)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}

--- a/gomig_test.go
+++ b/gomig_test.go
@@ -285,7 +285,6 @@ schemas: [{
 			}
 			tex, tname := ex, name
 			t.Run(tname, func(t *testing.T) {
-				t.Log(start.Version(), end.Version())
 				tinst, lacunas, err := tex.Translate(end.Version())
 				require.NoError(t, err)
 				assert.Nil(t, lacunas, "pure go migrations cannot emit lacunas")
@@ -360,6 +359,12 @@ schemas: [{
 			Mapper: func(inst *Instance, to Schema) (*Instance, error) { return nil, nil },
 		})...))
 		assert.Error(t, err, "expected error when providing Go migration for minor version upgrade")
+
+		_, err = BindLineage(linval, rt, ImperativeLenses(append(correctLenses[:1], ImperativeLens{
+			To:   SV(2, 0),
+			From: SV(1, 1),
+		})...))
+		assert.Error(t, err, "expected error when Mapper func is nil")
 	})
 }
 

--- a/instance.go
+++ b/instance.go
@@ -276,7 +276,7 @@ func (i *Instance) translateGo(to SyntacticVersion) (*Instance, TranslationLacun
 		var err error
 		if to.Less(from) || sch.Version()[0] != nsch.Version()[0] {
 			// Going backward, or crossing major version - need explicit lens
-			mlid := lid(nsch.Version(), sch.Version())
+			mlid := lid(sch.Version(), nsch.Version())
 			rti, err = lensmap[mlid].Mapper(ti, nsch)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error executing %s migration: %w", mlid, err)

--- a/instance.go
+++ b/instance.go
@@ -100,6 +100,15 @@ func (i *Instance) Dehydrate() *Instance {
 // schema.
 func (i *Instance) AsSuccessor() (*Instance, TranslationLacunas, error) {
 	i.check()
+	// If it's a minor version upgrade, we can safely shortcut and just create
+	// a new instance
+	nsch := i.Schema().Successor()
+	if nsch.Version()[0] == i.Schema().Version()[0] {
+		ni := new(Instance)
+		*ni = *i
+		ni.sch = nsch
+		return ni, nil, nil
+	}
 	return i.Translate(i.sch.Successor().Version())
 }
 
@@ -256,23 +265,40 @@ func (i *Instance) translateGo(to SyntacticVersion) (*Instance, TranslationLacun
 	ti := new(Instance)
 	*ti = *i
 	for sch.Version() != to {
-		rti, err := lensmap[lid(sch.Version(), ti.Schema().Version())].Mapper(ti, sch)
-		if err != nil {
-			return nil, nil, err
+		var nsch Schema
+		if to.Less(from) {
+			nsch = sch.Predecessor()
+		} else {
+			nsch = sch.Successor()
 		}
-		// Ensure the returned instance exists and the caller returned an instance of the expected schema version
-		if rti == nil {
-			return nil, nil, fmt.Errorf("lens returned a nil instance")
-		}
-		if rti.Schema().Version() != sch.Version() {
-			return nil, nil, fmt.Errorf("lens returned an instance of the wrong schema version: expected %v, got %v", sch.Version(), ti.Schema().Version())
+
+		var rti *Instance
+		var err error
+		if to.Less(from) || sch.Version()[0] != nsch.Version()[0] {
+			// Going backward, or crossing major version - need explicit lens
+			mlid := lid(nsch.Version(), sch.Version())
+			rti, err = lensmap[mlid].Mapper(ti, nsch)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error executing %s migration: %w", mlid, err)
+			}
+			// Ensure that
+			//  - the returned instance exists
+			//  - the caller returned an instance of the expected schema version
+			if rti == nil {
+				return nil, nil, fmt.Errorf("lens returned a nil instance")
+			}
+			if rti.Schema().Version() != nsch.Version() {
+				return nil, nil, fmt.Errorf("lens returned an instance of the wrong schema version: expected %v, got %v", nsch.Version(), rti.Schema().Version())
+			}
+		} else {
+			// going up a minor version - neither errors nor lacunas are possible
+			rti, _, err = ti.AsSuccessor()
+			if err != nil {
+				panic(fmt.Sprintf("unreachable - error on minor version upgrade: %s", err))
+			}
 		}
 		*ti = *rti
-		if to.Less(from) {
-			sch = sch.Predecessor()
-		} else {
-			sch = sch.Successor()
-		}
+		sch = nsch
 	}
 
 	return ti, nil, nil

--- a/lineage.go
+++ b/lineage.go
@@ -40,7 +40,7 @@ type baseLineage struct {
 	// all the schemas
 	allsch []*schemaDef
 
-	implens []ImperativeLens
+	lensmap map[lensID]ImperativeLens
 }
 
 // BindLineage takes a raw [cue.Value], checks that it correctly follows Thema's
@@ -143,6 +143,7 @@ func BindLineage(v cue.Value, rt *Runtime, opts ...BindOption) (Lineage, error) 
 		uni:       ml.uni,
 		allsch:    ml.schlist,
 		allv:      ml.allv,
+		lensmap:   ml.lensmap,
 	}
 
 	for _, sch := range lin.allsch {

--- a/lineage.go
+++ b/lineage.go
@@ -7,6 +7,7 @@ import (
 	"cuelang.org/go/cue"
 	cerrors "cuelang.org/go/cue/errors"
 	"github.com/cockroachdb/errors"
+
 	terrors "github.com/grafana/thema/errors"
 	"github.com/grafana/thema/internal/cuetil"
 )
@@ -38,6 +39,8 @@ type baseLineage struct {
 
 	// all the schemas
 	allsch []*schemaDef
+
+	implens []ImperativeLens
 }
 
 // BindLineage takes a raw [cue.Value], checks that it correctly follows Thema's
@@ -105,11 +108,12 @@ func BindLineage(v cue.Value, rt *Runtime, opts ...BindOption) (Lineage, error) 
 	}
 
 	ml := &maybeLineage{
-		rt:   rt,
-		orig: orig,
-		raw:  raw,
-		uni:  uni,
-		cfg:  cfg,
+		rt:      rt,
+		orig:    orig,
+		raw:     raw,
+		uni:     uni,
+		cfg:     cfg,
+		implens: cfg.implens,
 	}
 
 	if err := ml.checkExists(cfg); err != nil {

--- a/surface.go
+++ b/surface.go
@@ -85,7 +85,8 @@ type Lineage interface {
 	allVersions() versionList
 }
 
-// ImperativeLens is a lens transformation defined in Go code, rather than in CUE.
+// ImperativeLens is a lens transformation defined as a Go function, rather than
+// in native CUE alongside the lineage.
 //
 // See [ImperativeLenses] for more information.
 type ImperativeLens struct {
@@ -198,16 +199,19 @@ func SkipBuggyChecks() BindOption {
 // ImperativeLenses takes a slice of [ImperativeLens]. These lenses will be
 // executed on calls to [Instance.Translate].
 //
-// A mix of Go and CUE lenses may be provided, but only one lens may be provided
-// across both languages for each necessary lens. If the set of lenses is
-// incomplete, or a duplicate lens is provided, [BindLineage] will fail.
+// Currently, the entire lens set must be provided in either Go or CUE. This
+// restriction may be relaxed in the future to allow a mix of Go and CUE lenses,
+// or to allow Go funcs to supersede CUE lenses as a performance optimization.
 //
-// Lenses written in Go are Turing-complete, and therefore cannot be checked for
-// correctness.
+// When providing lenses in this way, [BindLineage] will fail unless exactly the
+// set of expected lenses is provided. The correctness of the function bodies
+// cannot be pre-verified in this way, as Go is Turing-complete, but it is enforced
+// at runtime that lenses return an [Instance] of the schema version they claim to
+// in [ImperativeLens.To].
 //
-// Writing lenses in Go means that the pure CUE declarations are no longer
-// sufficient to produce a valid lineage. As a result, lineages are no longer
-// portable outside of a context with access to the Go-defined lenses.
+// Writing lenses in Go means that pure native CUE is no longer sufficient to
+// produce a valid lineage. As a result, lineages are no longer portable outside
+// of Go programs with compile-time access to the Go-defined lenses.
 func ImperativeLenses(lenses ...ImperativeLens) BindOption {
 	return func(c *bindConfig) {
 		c.implens = append(c.implens, lenses...)

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -192,7 +192,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "foo"
+        withDefault: "bar"
     }
 },
 {
@@ -205,7 +205,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "foo"
+        withDefault: "bar"
     }
 },
 {
@@ -218,7 +218,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "foo"
+        withDefault: "bar"
     }
 },
 {
@@ -233,7 +233,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "foo"
+        withDefault: "bar"
     }
 }]
 -- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.0.json --

--- a/testdata/lineage/basic-multiversion.txtar
+++ b/testdata/lineage/basic-multiversion.txtar
@@ -192,7 +192,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "bar"
+        withDefault: "foo"
     }
 },
 {
@@ -205,7 +205,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "bar"
+        withDefault: "foo"
     }
 },
 {
@@ -218,7 +218,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "bar"
+        withDefault: "foo"
     }
 },
 {
@@ -233,7 +233,7 @@ lenses: [{
             optional: input.optional
         }
         // TODO: withDefault: input.withDefault doesn't work
-        withDefault: "bar"
+        withDefault: "foo"
     }
 }]
 -- out/core/instance/translate/TestInstance_Translate/lineage/basic-multiversion-0.0-simple->0.0.json --


### PR DESCRIPTION
This introduces an alternate mechanism for writing lenses: passing in a slice of `ImperativeLens` to `BindLineage`:

```go
type ImperativeLens struct {
	To, From SyntacticVersion
	Mapper   func(inst *Instance, to Schema) (*Instance, error)
}
```

where each function has exactly the same scope of responsibility as would otherwise be fulfilled by a declarative lens written in CUE.

The caller provides these via a new `BindOption` called `ImperativeLenses()`. In the current implementation, the caller must choose to implement their lenses entirely in Go, or entirely in CUE. We could relax this later.

This isn't fully ready - definitely needs more tests, and the requisite changes to `Translate()` aren't yet implemented. (Though i think those will be like another 40 LoC...trivial). But the test that exists so far at least verifies the correctness of the checker which ensures all and only the exact set of Go migrations are being provided.

The test also shows what actually writing Go lenses might plausibly look like - though **PLEASE NOTE** that when this is put to use in kindsys, we'll be putting in a wrapping layer so that the developer doesn't need to interact directly with `*thema.Instance`.