### PR TITLE
Fix invalid unassignability check for lists of structs

### DIFF
--- a/assignable.go
+++ b/assignable.go
@@ -181,7 +181,7 @@ func assignable(sch cue.Value, T interface{}) error {
 			// just drop the marked/default value, and not indicate an OrOp at all. This is handy,
 			// but unexpected behavior, and it feels dangerous to rely on.
 			_, evals := sval.Expr()
-			if len(evals) != 1 {
+			if len(evals) > 2 {
 				errs[p.String()] = fmt.Errorf("%s: schema is a complex disjunction of list types, may only correspond to interface{}/any", p)
 				return
 			}


### PR DESCRIPTION
### What

Fix list checking logic to include default values in list expression length check (i.e. check that there are two values when a default one is present), since the underlying issue in CUE has been resolved - calling `.Expr` no longer drops the default value.

### Why

The reason is above, the underlying issue in CUE seems to have been resolved. This fixes a weird issue when using Thema with https://github.com/grafana/grafana-app-sdk and the following schema:

```cue
package kinds

test: {
	name:  "Test"
	group: "some"

	crd: {
		scope: "Namespaced"
	}

	codegen: {
		backend:  true
		frontend: false
	}

	lineage: {
		schemas: [{
			version: [0, 0]
			schema: {
				#Struct: {
					foo: string
				}

				#AnotherStruct: {
					foo: #Struct
				}

				spec: {
					foo: string
				}

				status: {
					foo: [...#Struct]
					bar: [...#AnotherStruct]
				}
			}
		}]
	}
}
```

Which results in a false-positive unassignability error:
```terminal
panic: status.foo: schema is a complex disjunction of list types, may only correspond to interface{}/any
status.bar: schema is a complex disjunction of list types, may only correspond to interface{}/any
```

